### PR TITLE
MAINT Replace fasthash dependency with seahash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ overflow-checks = false
 [dependencies]
 regex = "1"
 lazy_static = "1.2.0"
-fasthash = "0.3"
+seahash = "3.0.6"
 ndarray = "0.12.1"
 sprs = "0.6.3"
 unicode-segmentation = "1.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ let documents = vec![
 
 #[macro_use]
 extern crate lazy_static;
-extern crate fasthash;
+extern crate seahash;
 extern crate regex;
 #[macro_use]
 extern crate ndarray;
@@ -239,7 +239,7 @@ impl HashingVectorizer {
             let tokens = tokenizer.tokenize(&document);
             indices_local.clear();
             for token in tokens {
-                let hash = fasthash::murmur3::hash32(&token);
+                let hash = seahash::hash_seeded(token.as_bytes(), 1, 1000, 200, 89) as u32;
                 let hash = hash % self.n_features;
 
                 indices_local.push(hash);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@ let documents = vec![
 
 #[macro_use]
 extern crate lazy_static;
-extern crate seahash;
 extern crate regex;
+extern crate seahash;
 #[macro_use]
 extern crate ndarray;
 extern crate hashbrown;
@@ -98,7 +98,7 @@ fn _sum_duplicates(tf: &mut CSRArray, indices_local: &[u32], nnz: &mut usize) {
 pub struct HashingVectorizer {
     lowercase: bool,
     token_pattern: String,
-    n_features: u32,
+    n_features: u64,
 }
 
 #[derive(Debug)]
@@ -239,8 +239,9 @@ impl HashingVectorizer {
             let tokens = tokenizer.tokenize(&document);
             indices_local.clear();
             for token in tokens {
-                let hash = seahash::hash_seeded(token.as_bytes(), 1, 1000, 200, 89) as u32;
-                let hash = hash % self.n_features;
+                // set the RNG seeds to get reproducible hashing
+                let hash = seahash::hash_seeded(token.as_bytes(), 1, 1000, 200, 89);
+                let hash = (hash % self.n_features) as u32;
 
                 indices_local.push(hash);
             }


### PR DESCRIPTION
fasthash (used in `HashingVectorizer`) is not portable and in particular, does not seem to support Windows (cf #7).

This replaces it with the [seahash crate](https://docs.rs/seahash/3.0.6/seahash/).