### PR TITLE
Add VTextTokenizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ debug = false
 rpath = false
 lto = false
 debug-assertions = false
-codegen-units = 16
 panic = 'unwind'
-incremental = false
 overflow-checks = false
 
 [dependencies]

--- a/benchmarks/bench_tokenizers.py
+++ b/benchmarks/bench_tokenizers.py
@@ -40,10 +40,7 @@ if __name__ == "__main__":
             "UnicodeSegmentTokenizer(word_bounds=True)",
             UnicodeSegmentTokenizer(word_bounds=True).tokenize,
         ),
-        (
-            "VTextTokenizer('en')",
-            VTextTokenizer("en").tokenize,
-        ),
+        ("VTextTokenizer('en')", VTextTokenizer("en").tokenize),
     ]:
 
         t0 = time()

--- a/benchmarks/bench_tokenizers.py
+++ b/benchmarks/bench_tokenizers.py
@@ -5,6 +5,7 @@ import re
 
 from vtext.tokenize import RegexpTokenizer
 from vtext.tokenize import UnicodeSegmentTokenizer
+from vtext.tokenize import VTextTokenizer
 
 base_dir = Path(__file__).parent.parent.resolve()
 
@@ -38,6 +39,10 @@ if __name__ == "__main__":
         (
             "UnicodeSegmentTokenizer(word_bounds=True)",
             UnicodeSegmentTokenizer(word_bounds=True).tokenize,
+        ),
+        (
+            "VTextTokenizer('en')",
+            VTextTokenizer("en").tokenize,
         ),
     ]:
 

--- a/python/run_docker_env.sh
+++ b/python/run_docker_env.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -v $PWD/../:/src -it --entrypoint "/bin/bash" konstin2/pyo3-pack:0.5.0
+docker run --rm -v $PWD/../:/src -it --net=host --entrypoint "/bin/bash" konstin2/pyo3-pack:0.5.0

--- a/python/run_docker_env.sh
+++ b/python/run_docker_env.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -v $PWD/../:/src -it --net=host --entrypoint "/bin/bash" konstin2/pyo3-pack:0.5.0
+docker run --rm -v $PWD/../:/src -it --entrypoint "/bin/bash" konstin2/pyo3-pack:0.5.0

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = vtextpy
-version = attr: vtext.__version__
 description = Natural Language Processing in Rust with Python bidings
 long_description = file: README.rst
 long_description_content_type = "text/markdown"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,6 +6,7 @@ with open("./requirements.txt", "rt") as fh:
     install_requires = fh.read().splitlines()
 
 setup(
+    version="0.1.a1",
     rust_extensions=[
         RustExtension(
             "vtext._lib",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -193,7 +193,7 @@ impl VTextTokenizer {
     /// ## Returns
     ///  - tokens : List<str>
     fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
-        let tokenizer = vtext::tokenize::VTextTokenizer::new(self.lang);
+        let tokenizer = vtext::tokenize::VTextTokenizer::new(&self.lang);
 
         let x = x.to_string();
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -165,6 +165,48 @@ impl UnicodeSegmentTokenizer {
     }
 }
 
+
+/// VText tokenizer
+///
+/// A tokenization that extends `unicode-segmentation` crate
+///
+/// ## References
+///
+/// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
+#[pyclass]
+pub struct VTextTokenizer {
+    pub lang: String,
+}
+
+#[pymethods]
+impl VTextTokenizer {
+    #[new]
+    fn __new__(obj: &PyRawObject, lang: String) -> PyResult<()> {
+        obj.init(|_token| VTextTokenizer {
+            lang: lang,
+        })
+    }
+
+    /// Tokenize a string
+    ///
+    /// ## Parameters
+    ///  - x : bool
+    ///    the string to tokenize
+    ///
+    /// ## Returns
+    ///  - tokens : List<str>
+    fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
+        let tokenizer = vtext::tokenize::VTextTokenizer::new(self.lang);
+
+        let x = x.to_string();
+
+        let res = tokenizer.tokenize(&x);
+        let res = res.map(|s| s.to_string()).collect();
+        Ok((res))
+    }
+}
+
+
 /// Tokenize a document using regular expressions
 #[pyclass]
 pub struct RegexpTokenizer {
@@ -271,6 +313,7 @@ fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<_CountVectorizerWrapper>()?;
     m.add_class::<UnicodeSegmentTokenizer>()?;
     m.add_class::<RegexpTokenizer>()?;
+    m.add_class::<VTextTokenizer>()?;
     m.add_class::<SnowballStemmer>()?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -165,7 +165,6 @@ impl UnicodeSegmentTokenizer {
     }
 }
 
-
 /// VText tokenizer
 ///
 /// A tokenization that extends `unicode-segmentation` crate
@@ -182,9 +181,7 @@ pub struct VTextTokenizer {
 impl VTextTokenizer {
     #[new]
     fn __new__(obj: &PyRawObject, lang: String) -> PyResult<()> {
-        obj.init(|_token| VTextTokenizer {
-            lang: lang,
-        })
+        obj.init(|_token| VTextTokenizer { lang: lang })
     }
 
     /// Tokenize a string
@@ -205,7 +202,6 @@ impl VTextTokenizer {
         Ok((res))
     }
 }
-
 
 /// Tokenize a document using regular expressions
 #[pyclass]

--- a/python/vtext/tokenize.py
+++ b/python/vtext/tokenize.py
@@ -1,5 +1,6 @@
 from ._lib import UnicodeSegmentTokenizer
 from ._lib import RegexpTokenizer
+from ._lib import VTextTokenizer
 
 
-__all__ = ["UnicodeSegmentTokenizer", "RegexpTokenizer"]
+__all__ = ["UnicodeSegmentTokenizer", "RegexpTokenizer", "VTextTokenizer"]

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -75,7 +75,7 @@ impl VTextTokenizer {
     /// Create a new instance
     pub fn new(lang: &str) -> VTextTokenizer {
         VTextTokenizer {
-            lang: lang.to_string()
+            lang: lang.to_string(),
         }
     }
     /// Tokenize a string
@@ -84,7 +84,6 @@ impl VTextTokenizer {
 
         let mut res: Vec<&'a str> = Vec::new();
         for tok in tokens {
-
             // Handle contractions
             if let Some(apostroph_idx) = tok.find(&"'") {
                 let mut apostroph_idx = apostroph_idx;
@@ -103,15 +102,15 @@ impl VTextTokenizer {
                 res.push(&tok[..apostroph_idx]);
                 res.push(&tok[apostroph_idx..]);
             } else {
-               res.push(tok);
+                res.push(tok);
             }
+        }
 
         // remove whitespace tokens
         let res = res.into_iter().filter(|x| x != &" ");
         return Box::new(res);
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -149,7 +148,6 @@ mod tests {
 
     #[test]
     fn test_vtext_tokenizer_en() {
-
         let tokenizer = VTextTokenizer::new("en");
 
         let s = "We can't";

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -4,6 +4,30 @@ extern crate unicode_segmentation;
 use regex::Regex;
 use unicode_segmentation::UnicodeSegmentation;
 
+/// Regular expression tokenizer
+///
+#[derive(Debug)]
+pub struct RegexpTokenizer {
+    pub pattern: String,
+    regexp: Regex,
+}
+
+impl RegexpTokenizer {
+    /// Create a new instance
+    pub fn new(pattern: String) -> RegexpTokenizer {
+        let regexp = Regex::new(&pattern).unwrap();
+
+        RegexpTokenizer {
+            pattern: pattern,
+            regexp: regexp,
+        }
+    }
+    /// Tokenize a string
+    pub fn tokenize<'a>(&'a self, text: &'a str) -> impl Iterator<Item = &'a str> {
+        self.regexp.find_iter(text).map(|m| m.as_str())
+    }
+}
+
 /// Unicode Segmentation tokenizer
 ///
 /// This implementation is a thin wrapper around the
@@ -35,33 +59,62 @@ impl UnicodeSegmentTokenizer {
     }
 }
 
-/// Regular expression tokenizer
+/// vtext tokenizer
 ///
+/// This tokenizer builds upon the `unicode-segmentation` crate
+///
+/// ## References
+///
+/// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
 #[derive(Debug)]
-pub struct RegexpTokenizer {
-    pub pattern: String,
-    regexp: Regex,
+pub struct VTextTokenizer {
+    pub lang: String,
 }
 
-impl RegexpTokenizer {
+impl VTextTokenizer {
     /// Create a new instance
-    pub fn new(pattern: String) -> RegexpTokenizer {
-        let regexp = Regex::new(&pattern).unwrap();
-
-        RegexpTokenizer {
-            pattern: pattern,
-            regexp: regexp,
+    pub fn new(lang: &str) -> VTextTokenizer {
+        VTextTokenizer {
+            lang: lang.to_string()
         }
     }
     /// Tokenize a string
-    pub fn tokenize<'a>(&'a self, text: &'a str) -> impl Iterator<Item = &'a str> {
-        self.regexp.find_iter(text).map(|m| m.as_str())
+    pub fn tokenize<'a>(&self, text: &'a str) -> Box<Iterator<Item = &'a str> + 'a> {
+        let tokens = text.split_word_bounds();
+
+        let mut res: Vec<&'a str> = Vec::new();
+        for tok in tokens {
+            let n_chars = tok.chars().count();
+            if tok.ends_with(&"n't") {
+               res.push(&tok[0..n_chars-3]);
+               res.push(&tok[n_chars-3..n_chars]);
+            } else if tok.ends_with(&"'s") {
+               res.push(&tok[0..n_chars-2]);
+               res.push(&tok[n_chars-2..n_chars]);
+            } else {
+               res.push(tok);
+            }
+        }
+        // remove whitespace tokens
+        let res = res.into_iter().filter(|x| x != &" ");
+        return Box::new(res);
     }
 }
 
+
 #[cfg(test)]
 mod tests {
-    use crate::tokenize::{RegexpTokenizer, UnicodeSegmentTokenizer};
+    use crate::tokenize::{RegexpTokenizer, UnicodeSegmentTokenizer, VTextTokenizer};
+
+    #[test]
+    fn test_regexp_tokenizer() {
+        let s = "fox can't jump 32.3 feet, right?";
+
+        let tokenizer = RegexpTokenizer::new(r"\b\w\w+\b".to_string());
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
+        assert_eq!(tokens, b);
+    }
 
     #[test]
     fn test_unicode_tokenizer() {
@@ -84,12 +137,19 @@ mod tests {
     }
 
     #[test]
-    fn test_regexp_tokenizer() {
-        let s = "fox can't jump 32.3 feet, right?";
+    fn test_vtext_tokenizer() {
 
-        let tokenizer = RegexpTokenizer::new(r"\b\w\w+\b".to_string());
+        let tokenizer = VTextTokenizer::new("en");
+
+        let s = "We can't";
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
-        assert_eq!(tokens, b);
+        let tokens_ref: &[_] = &["We", "ca", "n't"];
+        assert_eq!(tokens, tokens_ref);
+
+        let s = "it's";
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        let tokens_ref: &[_] = &["it", "'s"];
+        assert_eq!(tokens, tokens_ref);
     }
+
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -152,18 +152,20 @@ mod tests {
 
         let s = "We can't";
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        let tokens_ref: &[_] = &["We", "ca", "n't"];
-        assert_eq!(tokens, tokens_ref);
+        assert_eq!(tokens, &["We", "ca", "n't"]);
 
         let s = "it's";
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        let tokens_ref: &[_] = &["it", "'s"];
-        assert_eq!(tokens, tokens_ref);
+        assert_eq!(tokens, &["it", "'s"]);
 
         let s = "it’s";
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        let tokens_ref: &[_] = &["it", "’s"];
-        assert_eq!(tokens, tokens_ref);
+        assert_eq!(tokens, &["it", "’s"]);
+
+        let s = "N.Y.";
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        // TODO
+        // assert_eq!(tokens, &["N.Y."]);
     }
 
     #[test]
@@ -172,9 +174,8 @@ mod tests {
 
         let s = "name@domain.com";
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        let tokens_ref: &[_] = &["name@domain.com"];
         // TODO
-        // assert_eq!(tokens, tokens_ref);
+        // assert_eq!(tokens, &["name@domain.com"]);
 
     }
 

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -166,4 +166,16 @@ mod tests {
         assert_eq!(tokens, tokens_ref);
     }
 
+    #[test]
+    fn test_vtext_tokenizer_all_lang() {
+        let tokenizer = VTextTokenizer::new("en");
+
+        let s = "name@domain.com";
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        let tokens_ref: &[_] = &["name@domain.com"];
+        // TODO
+        // assert_eq!(tokens, tokens_ref);
+
+    }
+
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -85,10 +85,10 @@ impl VTextTokenizer {
         let mut res: Vec<&'a str> = Vec::new();
         for tok in tokens {
             let n_chars = tok.chars().count();
-            if tok.ends_with(&"n't") {
+            if tok.ends_with(&"n't") || tok.ends_with(&"n’t") {
                res.push(&tok[0..n_chars-3]);
                res.push(&tok[n_chars-3..n_chars]);
-            } else if tok.ends_with(&"'s") {
+            } else if tok.ends_with(&"'s") || tok.ends_with(&"’s") {
                res.push(&tok[0..n_chars-2]);
                res.push(&tok[n_chars-2..n_chars]);
             } else {

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -166,6 +166,11 @@ mod tests {
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
         // TODO
         // assert_eq!(tokens, &["N.Y."]);
+
+        let s = "Hello :)";
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        // TODO
+        //assert_eq!(tokens, &["Hello", ":)"]);
     }
 
     #[test]
@@ -176,7 +181,6 @@ mod tests {
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
         // TODO
         // assert_eq!(tokens, &["name@domain.com"]);
-
     }
 
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -84,17 +84,28 @@ impl VTextTokenizer {
 
         let mut res: Vec<&'a str> = Vec::new();
         for tok in tokens {
-            let n_chars = tok.chars().count();
-            if tok.ends_with(&"n't") || tok.ends_with(&"n’t") {
-               res.push(&tok[0..n_chars-3]);
-               res.push(&tok[n_chars-3..n_chars]);
-            } else if tok.ends_with(&"'s") || tok.ends_with(&"’s") {
-               res.push(&tok[0..n_chars-2]);
-               res.push(&tok[n_chars-2..n_chars]);
+
+            // Handle contractions
+            if let Some(apostroph_idx) = tok.find(&"'") {
+                let mut apostroph_idx = apostroph_idx;
+                if tok.ends_with(&"n't") {
+                    // also include the "n" from "n't"
+                    apostroph_idx = apostroph_idx - 1;
+                }
+                res.push(&tok[..apostroph_idx]);
+                res.push(&tok[apostroph_idx..]);
+            } else if let Some(apostroph_idx) = tok.find(&"’") {
+                let mut apostroph_idx = apostroph_idx;
+                if tok.ends_with(&"n’t") {
+                    // also include the "n" from "n't"
+                    apostroph_idx = apostroph_idx - 1;
+                }
+                res.push(&tok[..apostroph_idx]);
+                res.push(&tok[apostroph_idx..]);
             } else {
                res.push(tok);
             }
-        }
+
         // remove whitespace tokens
         let res = res.into_iter().filter(|x| x != &" ");
         return Box::new(res);
@@ -137,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vtext_tokenizer() {
+    fn test_vtext_tokenizer_en() {
 
         let tokenizer = VTextTokenizer::new("en");
 
@@ -149,6 +160,11 @@ mod tests {
         let s = "it's";
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
         let tokens_ref: &[_] = &["it", "'s"];
+        assert_eq!(tokens, tokens_ref);
+
+        let s = "it’s";
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        let tokens_ref: &[_] = &["it", "’s"];
         assert_eq!(tokens, tokens_ref);
     }
 


### PR DESCRIPTION
Add a preliminary implementation of VTextTokenizer, that implements manual rules on top of unicode-segmentation aiming to improve tokenization accuracy on the [Universal Dependencies](https://universaldependencies.org/) corpus tokenization.