### PR TITLE
Improve french tokenizer

### DIFF
--- a/evaluation/eval_tokenization.py
+++ b/evaluation/eval_tokenization.py
@@ -33,28 +33,28 @@ def evaluate_tokenizer(treebank, tokenizer):
         tokens = [str(el) for el in tokenizer(txt)]
         tokens_ref = [el["form"] for el in sentence]
         similarity = tokens_similarity(tokens_ref, tokens)
-        # if similarity != 1:
-        #    print(f"Expected: {tokens_ref}")
-        #    print(f"Got:      {tokens}")
+        if similarity != 1:
+           print(f"Expected: {tokens_ref}")
+           print(f"Got:      {tokens}")
         scores.append(similarity)
     scores = np.mean(scores)
     return scores
 
 
 tb_list = [
-    ("English-GUM", "UD_English-GUM/en_gum-ud-train.conllu", "en"),
-    ("English-EWT", "UD_English-EWT/en_ewt-ud-train.conllu", "en"),
+    #("English-GUM", "UD_English-GUM/en_gum-ud-train.conllu", "en"),
+    #("English-EWT", "UD_English-EWT/en_ewt-ud-train.conllu", "en"),
     ("UD_French-GSD", "UD_French-GSD/fr_gsd-ud-train.conllu", "fr"),
     # ('Japanese-PUD', 'UD_Japanese-PUD/ja_pud-ud-test.conllu', "jp")
 ]
 
 
 tok_db = [  # ('whitespace', lambda x: x.split(' ')),
-    ("regexp", lambda lang: re.compile(r"\b\w\w+\b").findall),
-    (
-        "unicode-segmentation",
-        lambda lang: UnicodeSegmentTokenizer(word_bounds=True).tokenize,
-    ),
+    #("regexp", lambda lang: re.compile(r"\b\w\w+\b").findall),
+    #(
+    #    "unicode-segmentation",
+    #    lambda lang: UnicodeSegmentTokenizer(word_bounds=True).tokenize,
+    #),
     ("vtext", lambda lang: VTextTokenizer(lang).tokenize),
 ]
 

--- a/evaluation/eval_tokenization.py
+++ b/evaluation/eval_tokenization.py
@@ -33,18 +33,18 @@ def evaluate_tokenizer(treebank, tokenizer):
         tokens = [str(el) for el in tokenizer(txt)]
         tokens_ref = [el["form"] for el in sentence]
         similarity = tokens_similarity(tokens_ref, tokens)
-        # if similarity != 1:
-        #   print(f"Expected: {tokens_ref}")
-        #   print(f"Got:      {tokens}")
+        if similarity != 1:
+          print(f"Expected: {tokens_ref}")
+          print(f"Got:      {tokens}")
         scores.append(similarity)
     scores = np.mean(scores)
     return scores
 
 
 tb_list = [
-    ("English-GUM", "UD_English-GUM/en_gum-ud-train.conllu", "en"),
+    #("English-GUM", "UD_English-GUM/en_gum-ud-train.conllu", "en"),
     ("English-EWT", "UD_English-EWT/en_ewt-ud-train.conllu", "en"),
-    ("UD_French-Sequoia", "UD_French-Sequoia/fr_sequoia-ud-train.conllu", "fr"),
+    #("UD_French-Sequoia", "UD_French-Sequoia/fr_sequoia-ud-train.conllu", "fr"),
     # ("UD_Russian-GSD", "UD_Russian-GSD/ru_gsd-ud-train.conllu", "ru")
     # ('Japanese-PUD', 'UD_Japanese-PUD/ja_pud-ud-test.conllu', "jp")
 ]

--- a/evaluation/eval_tokenization.py
+++ b/evaluation/eval_tokenization.py
@@ -33,35 +33,36 @@ def evaluate_tokenizer(treebank, tokenizer):
         tokens = [str(el) for el in tokenizer(txt)]
         tokens_ref = [el["form"] for el in sentence]
         similarity = tokens_similarity(tokens_ref, tokens)
-        if similarity != 1:
-           print(f"Expected: {tokens_ref}")
-           print(f"Got:      {tokens}")
+        # if similarity != 1:
+        #   print(f"Expected: {tokens_ref}")
+        #   print(f"Got:      {tokens}")
         scores.append(similarity)
     scores = np.mean(scores)
     return scores
 
 
 tb_list = [
-    #("English-GUM", "UD_English-GUM/en_gum-ud-train.conllu", "en"),
-    #("English-EWT", "UD_English-EWT/en_ewt-ud-train.conllu", "en"),
-    ("UD_French-GSD", "UD_French-GSD/fr_gsd-ud-train.conllu", "fr"),
+    ("English-GUM", "UD_English-GUM/en_gum-ud-train.conllu", "en"),
+    ("English-EWT", "UD_English-EWT/en_ewt-ud-train.conllu", "en"),
+    ("UD_French-Sequoia", "UD_French-Sequoia/fr_sequoia-ud-train.conllu", "fr"),
+    # ("UD_Russian-GSD", "UD_Russian-GSD/ru_gsd-ud-train.conllu", "ru")
     # ('Japanese-PUD', 'UD_Japanese-PUD/ja_pud-ud-test.conllu', "jp")
 ]
 
 
 tok_db = [  # ('whitespace', lambda x: x.split(' ')),
-    #("regexp", lambda lang: re.compile(r"\b\w\w+\b").findall),
-    #(
+    # ("regexp", lambda lang: re.compile(r"\b\w\w+\b").findall),
+    # (
     #    "unicode-segmentation",
     #    lambda lang: UnicodeSegmentTokenizer(word_bounds=True).tokenize,
-    #),
-    ("vtext", lambda lang: VTextTokenizer(lang).tokenize),
+    # ),
+    ("vtext", lambda lang: VTextTokenizer(lang).tokenize)
 ]
 
 if sacremoses is not None:
     tok_db.append(("MosesTokenizer", lambda lang: sacremoses.MosesTokenizer().tokenize))
 
-if spacy is not None:
+if spacy is not None and False:
     tok_db.append(
         ("spacy", lambda lang: spacy.load(lang, parser=False, entity=False).tokenizer)
     )

--- a/evaluation/eval_tokenization.py
+++ b/evaluation/eval_tokenization.py
@@ -47,7 +47,7 @@ tb_list = [
     ("en", "EWT"),
     ("fr", "Sequoia"),
     ("de", "GSD"),
-    #("ru", "GSD"),
+    # ("ru", "GSD"),
 ]
 
 
@@ -56,7 +56,7 @@ def whitespace_split(x):
 
 
 tok_db = [
-    #("whitespace", lambda lang: whitespace_split),
+    # ("whitespace", lambda lang: whitespace_split),
     ("regexp", lambda lang: re.compile(r"\b\w\w+\b").findall),
     (
         "unicode-segmentation",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -167,7 +167,13 @@ impl UnicodeSegmentTokenizer {
 
 /// VText tokenizer
 ///
-/// A tokenization that extends `unicode-segmentation` crate
+/// This tokenizer a few additional rules on top of word boundaries computed
+/// by unicode segmentation.
+///
+/// Additional language specific rules are implemented for English (en),
+/// and French (en). Providing `lang` parameter with any other value, will siletly
+/// fallback to `lang="any"`.
+///
 ///
 /// ## References
 ///

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -134,6 +134,7 @@ impl _CountVectorizerWrapper {
 #[pyclass]
 pub struct UnicodeSegmentTokenizer {
     pub word_bounds: bool,
+    inner: vtext::tokenize::UnicodeSegmentTokenizer,
 }
 
 #[pymethods]
@@ -141,8 +142,11 @@ impl UnicodeSegmentTokenizer {
     #[new]
     #[args(word_bounds = true)]
     fn __new__(obj: &PyRawObject, word_bounds: bool) -> PyResult<()> {
+        let tokenizer = vtext::tokenize::UnicodeSegmentTokenizer::new(word_bounds);
+
         obj.init(|_token| UnicodeSegmentTokenizer {
             word_bounds: word_bounds,
+            inner: tokenizer,
         })
     }
 
@@ -155,11 +159,9 @@ impl UnicodeSegmentTokenizer {
     /// ## Returns
     ///  - tokens : List<str>
     fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
-        let tokenizer = vtext::tokenize::UnicodeSegmentTokenizer::new(self.word_bounds);
-
         let x = x.to_string();
 
-        let res = tokenizer.tokenize(&x);
+        let res = self.inner.tokenize(&x);
         let res = res.map(|s| s.to_string()).collect();
         Ok((res))
     }
@@ -181,13 +183,18 @@ impl UnicodeSegmentTokenizer {
 #[pyclass]
 pub struct VTextTokenizer {
     pub lang: String,
+    inner: vtext::tokenize::VTextTokenizer,
 }
 
 #[pymethods]
 impl VTextTokenizer {
     #[new]
     fn __new__(obj: &PyRawObject, lang: String) -> PyResult<()> {
-        obj.init(|_token| VTextTokenizer { lang: lang })
+        let tokenizer = vtext::tokenize::VTextTokenizer::new(&lang);
+        obj.init(|_token| VTextTokenizer {
+            lang: lang,
+            inner: tokenizer,
+        })
     }
 
     /// Tokenize a string
@@ -199,11 +206,9 @@ impl VTextTokenizer {
     /// ## Returns
     ///  - tokens : List<str>
     fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
-        let tokenizer = vtext::tokenize::VTextTokenizer::new(&self.lang);
-
         let x = x.to_string();
 
-        let res = tokenizer.tokenize(&x);
+        let res = self.inner.tokenize(&x);
         let res = res.map(|s| s.to_string()).collect();
         Ok((res))
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -171,8 +171,8 @@ impl UnicodeSegmentTokenizer {
 /// by unicode segmentation.
 ///
 /// Additional language specific rules are implemented for English (en),
-/// and French (en). Providing `lang` parameter with any other value, will siletly
-/// fallback to `lang="any"`.
+/// and French (en). Providing `lang` parameter with any other value, will silently
+/// fall back to `lang='any'`.
 ///
 ///
 /// ## References

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -123,6 +123,7 @@ impl VTextTokenizer {
                     }
                     res.push(&tok[..apostroph_idx]);
                     res.push(&tok[apostroph_idx..]);
+                    continue;
                 } else if let Some(apostroph_idx) = tok.find(&"’") {
                     let mut apostroph_idx = apostroph_idx;
                     if tok.ends_with(&"n’t") {
@@ -131,12 +132,21 @@ impl VTextTokenizer {
                     }
                     res.push(&tok[..apostroph_idx]);
                     res.push(&tok[apostroph_idx..]);
-                } else {
-                    res.push(tok);
+                    continue;
                 }
-            } else {
-                res.push(tok);
+            } else if &self.lang == "fr" {
+                // Handle English contractions
+                if let Some(apostroph_idx) = tok.find(&"'") {
+                    let apostroph_idx = apostroph_idx;
+                    if apostroph_idx == 1 {
+                        let apostroph_idx = apostroph_idx + "'".len();
+                        res.push(&tok[..apostroph_idx]);
+                        res.push(&tok[apostroph_idx..]);
+                        continue;
+                    }
+                }
             }
+            res.push(tok);
         }
 
         if punct_start_seq >= 0 {
@@ -203,6 +213,15 @@ mod tests {
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
         // TODO
         // assert_eq!(tokens, &["N.Y."]);
+    }
+
+    #[test]
+    fn test_vtext_tokenizer_fr() {
+        let tokenizer = VTextTokenizer::new("fr");
+
+        let s = "l'image";
+        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+        assert_eq!(tokens, &["l'", "image"]);
     }
 
     #[test]

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -76,18 +76,16 @@ pub struct VTextTokenizer {
 impl VTextTokenizer {
     /// Create a new instance
     pub fn new(lang: &str) -> VTextTokenizer {
-
-
         match lang {
-            "en" | "fr" => {},
+            "en" | "fr" => {}
             _ => {
-                    // TODO: add some warning message here
-                    //println!(
-                    //    "Warning: Lokenizer for {} \
-                    //     is not implemented! Falling back to the \
-                    //     language independent tokenizer!",
-                    //    lang
-                    //);
+                // TODO: add some warning message here
+                //println!(
+                //    "Warning: Lokenizer for {} \
+                //     is not implemented! Falling back to the \
+                //     language independent tokenizer!",
+                //    lang
+                //);
             }
         };
         VTextTokenizer {
@@ -163,8 +161,7 @@ impl VTextTokenizer {
                         }
                     }
                 }
-                _ => {
-                }
+                _ => {}
             };
             res.push(tok);
 

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -63,7 +63,13 @@ impl UnicodeSegmentTokenizer {
 
 /// vtext tokenizer
 ///
-/// This tokenizer builds upon the `unicode-segmentation` crate
+/// This tokenizer a few additional rules on top of word boundaries computed
+/// by unicode segmentation.
+///
+/// Additional language specific rules are implemented for English (en),
+/// and French (en). Providing `lang` parameter with any other value, will siletly
+/// fallback to `lang="any"`.
+///
 ///
 /// ## References
 ///
@@ -76,8 +82,8 @@ pub struct VTextTokenizer {
 impl VTextTokenizer {
     /// Create a new instance
     pub fn new(lang: &str) -> VTextTokenizer {
-        match lang {
-            "en" | "fr" => {}
+        let lang_valid = match lang {
+            "en" | "fr" => lang,
             _ => {
                 // TODO: add some warning message here
                 //println!(
@@ -86,10 +92,11 @@ impl VTextTokenizer {
                 //     language independent tokenizer!",
                 //    lang
                 //);
+                "any"
             }
         };
         VTextTokenizer {
-            lang: lang.to_string(),
+            lang: lang_valid.to_string(),
         }
     }
     /// Tokenize a string
@@ -170,7 +177,6 @@ impl VTextTokenizer {
                 let tok0 = res[res.len() - 3];
                 let tok1 = res[res.len() - 2];
                 let tok2 = res[res.len() - 1];
-                // merge on dashes, /, or @
                 if (tok0 != " ") & (tok2 != " ") & (tok0.len() > 0) & (tok2.len() > 0) {
                     let char0_last = tok0.chars().last().unwrap();
                     let char2_first = tok0.chars().next().unwrap();
@@ -292,6 +298,12 @@ mod tests {
             let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
             assert_eq!(&tokens, tokens_ref);
         }
+    }
+
+    #[test]
+    fn test_vtext_tokenizer_invalid_lang() {
+        let tokenizer = VTextTokenizer::new("unknown");
+        assert_eq!(tokenizer.lang, "any");
     }
 
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -214,83 +214,60 @@ mod tests {
     }
 
     #[test]
+    fn test_vtext_tokenizer_all_lang() {
+        let tokenizer = VTextTokenizer::new("en");
+
+        for (s, tokens_ref) in [
+            // float numbers
+            ("23.2 meters", vec!["23.2", "meters"]),
+            ("11,2 m", vec!["11,2", "m"]),
+            // repeated punctuation
+            ("1 ..", vec!["1", ".."]),
+            ("I ...", vec!["I", "..."]),
+            (", o ! o", vec![",", "o", "!", "o"]),
+            ("... ok.", vec!["...", "ok", "."]),
+            // dash separated words
+            ("porte-manteau", vec!["porte-manteau"]),
+            // emails
+            ("name@domain.com", vec!["name@domain.com"]),
+            ("1/2", vec!["1/2"]),
+            //("and/or", vec!["and", "/", "or"]),
+            // TODO
+            // ("Hello :)", vec!["Hello", ":)"])
+        ]
+        .iter()
+        {
+            let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+            assert_eq!(&tokens, tokens_ref);
+        }
+    }
+
+    #[test]
     fn test_vtext_tokenizer_en() {
         let tokenizer = VTextTokenizer::new("en");
 
-        let s = "We can't";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["We", "ca", "n't"]);
-
-        let s = "it's";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["it", "'s"]);
-
-        let s = "it’s";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["it", "’s"]);
-
-        let s = "N.Y.";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        // TODO
-        // assert_eq!(tokens, &["N.Y."]);
+        for (s, tokens_ref) in [
+            ("We can't", vec!["We", "ca", "n't"]),
+            ("it's", vec!["it", "'s"]),
+            ("it’s", vec!["it", "’s"]),
+            // TODO
+            //("N.Y.", vec!["N.Y."])
+        ]
+        .iter()
+        {
+            let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+            assert_eq!(&tokens, tokens_ref);
+        }
     }
 
     #[test]
     fn test_vtext_tokenizer_fr() {
         let tokenizer = VTextTokenizer::new("fr");
 
-        let s = "l'image";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["l'", "image"]);
-    }
-
-    #[test]
-    fn test_vtext_tokenizer_all_lang() {
-        let tokenizer = VTextTokenizer::new("en");
-
-        // float numbers
-        let s = "23.2 meters";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["23.2", "meters"]);
-
-        let s = "11,2 meters";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["11,2", "meters"]);
-
-        // repeated punctuation
-        let s = "1 ..";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["1", ".."]);
-
-        let s = "I ...";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["I", "..."]);
-
-        let s = ", o ! o";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &[",", "o", "!", "o"]);
-
-        let s = "... ok.";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["...", "ok", "."]);
-
-        // dash separated words
-        let s = "porte-manteau";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["porte-manteau"]);
-
-        let s = "name@domain.com";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["name@domain.com"]);
-
-        let s = "1/2";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        assert_eq!(tokens, &["1/2"]);
-
-        let s = "Hello :)";
-        let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
-        // TODO
-        //assert_eq!(tokens, &["Hello", ":)"]);
+        for (s, tokens_ref) in [("l'image", vec!["l'", "image"])].iter() {
+            let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
+            assert_eq!(&tokens, tokens_ref);
+        }
     }
 
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -260,6 +260,8 @@ mod tests {
             ("8:30", vec!["8:30"]),
             ("B&B", vec!["B&B"]),
             // TODO ("Hello :)", vec!["Hello", ":)"])
+            // TODO ("http://www.youtube.com/watch?v=q2lDF0XU3NI",
+            // vec!["http://www.youtube.com/watch?v=q2lDF0XU3NI"])
         ]
         .iter()
         {

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -155,14 +155,12 @@ impl VTextTokenizer {
                 let tok1 = res[res.len() - 2];
                 let tok2 = res[res.len() - 1];
                 // merge on dashes, /, or @
-                if ((tok1 == "-") | (tok1 == "@") | (tok1 == "/"))
-                    & (tok0 != " ")
-                    & (tok2 != " ")
-                    & (tok0.len() > 0)
-                    & (tok2.len() > 0)
-                {
-                    if tok0.chars().last().unwrap().is_alphanumeric()
-                        & tok2.chars().next().unwrap().is_alphanumeric()
+                if (tok0 != " ") & (tok2 != " ") & (tok0.len() > 0) & (tok2.len() > 0) {
+                    let char0_last = tok0.chars().last().unwrap();
+                    let char2_first = tok0.chars().next().unwrap();
+                    if ((tok1 == "-") | (tok1 == "@") | (tok1 == "/"))
+                        & char0_last.is_alphanumeric()
+                        & char2_first.is_alphanumeric()
                     {
                         res.truncate(res.len() - 3);
                         res.push(&text[str_idx - tok0.len() - tok1.len() - tok2.len()..str_idx]);


### PR DESCRIPTION
This adds some specific rules for french tokenization, and improves the language independent tokenizer following #28 .

Latest UD treebank evaluation results are,
```
tokenizer      regexp  spacy  unicode-segmentation  vtext
lang treebank                                            
de   GSD        0.818  0.934                 0.953  0.947
en   EWT        0.743  0.975                 0.927  0.968
     GUM        0.807  0.994                 0.980  0.997
fr   Sequoia    0.748  0.946                 0.861  0.943
```