### PR TITLE
ENH Improve CountVectorizer performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ and the English tokenization speed,
 Below are  benchmarks for converting
 textual data to a sparse document-term matrix using the 20 newsgroups dataset, 
 
-| Speed (MB/s)       | scikit-learn 0.20.1 | vtext 0.1.0a1 |
-|--------------------|---------------------|---------------|
-| CountVectorizer    |  14                 | 35            |
-| HashingVectorizer  |  19                 | 68            |
+| Speed (MB/s)       | scikit-learn 0.20.1 | vtext |
+|--------------------|---------------------|-------|
+| CountVectorizer    |  14                 | 45    |
+| HashingVectorizer  |  19                 | 68    |
 
 
 see [benchmarks/README.md](./benchmarks/README.md) for more details.

--- a/benchmarks/bench_vectorizers.py
+++ b/benchmarks/bench_vectorizers.py
@@ -27,10 +27,10 @@ if __name__ == "__main__":
         ),
         ("CountVectorizer (vtext)", vtext.vectorize.CountVectorizer(lowercase=False)),
         ("CountVectorizer (scikit-learn)", skt.CountVectorizer(lowercase=False)),
-        (
-            "CountVectorizer, 4-char ngram (scikit-learn)",
-            skt.CountVectorizer(lowercase=False, analyzer="char", ngram_range=(4, 4)),
-        ),
+        # (
+        #    "CountVectorizer, 4-char ngram (scikit-learn)",
+        #    skt.CountVectorizer(lowercase=False, analyzer="char", ngram_range=(4, 4)),
+        # ),
     ]:
 
         t0 = time()

--- a/doc/benchmarks.rst
+++ b/doc/benchmarks.rst
@@ -32,10 +32,10 @@ Text vectorization
 Below are  benchmarks for converting
 textual data to a sparse document-term matrix using the 20 newsgroups dataset, 
 
- ===================  =====================  ===============
-  Speed (MB/s)         scikit-learn 0.20.1    vtext 0.1.0a1
- ===================  =====================  ===============
-  CountVectorizer       14                     35
+ ===================  =====================  =======
+  Speed (MB/s)         scikit-learn 0.20.1    vtext
+ ===================  =====================  =======
+  CountVectorizer       14                     45
   HashingVectorizer     19                     68
- ===================  =====================  ===============
+ ===================  =====================  =======
 

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -51,7 +51,7 @@ fn _sort_features(X: &mut CSRArray, vocabulary: &mut HashMap<String, i32>) {
 
 /// Sum duplicates
 #[inline]
-fn _sum_duplicates(tf: &mut CSRArray, indices_local: &[u32], nnz: &mut usize) {
+fn _sum_duplicates(tf: &mut CSRArray, indices_local: &[i32], nnz: &mut usize) {
     let mut bucket: i32 = 0;
     let mut index_last = indices_local[0];
 
@@ -131,28 +131,33 @@ impl CountVectorizer {
             HashMap::with_capacity_and_hasher(1000, Default::default());
 
         let mut nnz: usize = 0;
-        let mut indices_local = Vec::new();
+        let mut indices_local: Vec<i32> = Vec::new();
 
         let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
         let pipe = X.iter().map(|doc| doc.to_ascii_lowercase());
 
+        let mut vocabulary_size: i32 = 0;
         for (_document_id, document) in pipe.enumerate() {
             let tokens = tokenizer.tokenize(&document);
 
             indices_local.clear();
             for token in tokens {
-                let vocabulary_size = vocabulary.len() as i32;
-                // TODO: don't convert to Sting here
-                let token_id = vocabulary
-                    .entry(token.to_string())
-                    .or_insert(vocabulary_size);
-                indices_local.push(*token_id as u32);
+                let token_id = match vocabulary.get(token) {
+                    Some(_id) => *_id,
+                    None => {
+                        vocabulary.insert(token.to_string(), vocabulary_size);
+                        vocabulary_size += 1;
+                        vocabulary_size - 1 as i32
+                    }
+                };
+
+                indices_local.push(token_id);
             }
             // this takes 10-15% of the compute time
             indices_local.sort_unstable();
 
-            _sum_duplicates(&mut tf, &indices_local, &mut nnz);
+            _sum_duplicates(&mut tf, indices_local.as_slice(), &mut nnz);
         }
 
         // Copy to the vocabulary in the struct and make it own data
@@ -222,14 +227,14 @@ impl HashingVectorizer {
             for token in tokens {
                 // set the RNG seeds to get reproducible hashing
                 let hash = seahash::hash_seeded(token.as_bytes(), 1, 1000, 200, 89);
-                let hash = (hash % self.n_features) as u32;
+                let hash = (hash % self.n_features) as i32;
 
                 indices_local.push(hash);
             }
             // this takes 10-15% of the compute time
             indices_local.sort_unstable();
 
-            _sum_duplicates(&mut tf, &indices_local, &mut nnz);
+            _sum_duplicates(&mut tf, indices_local.as_slice(), &mut nnz);
         }
 
         CsMat::new(


### PR DESCRIPTION
This Improves `CountVectorizer` performance (making it around 30% faster) by avoiding casting tokens from `&str` to `String` while checking if a token is already in the vocabulary.