### PR TITLE
Parallel CountVectorizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 MANIFEST
 __pycache__/
 *.pyc
+*.swp
 
 # Unit test / coverage reports
 htmlcov/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,5 @@ itertools = "0.8"
 ndarray = "0.12.1"
 sprs = "0.6.3"
 unicode-segmentation = "1.2.1"
-hashbrown = "0.1"
+hashbrown = { version = "0.3", features = ["rayon"] }
 rayon = "1.0"

--- a/benchmarks/bench_vectorizers.py
+++ b/benchmarks/bench_vectorizers.py
@@ -21,35 +21,54 @@ if __name__ == "__main__":
 
     for label, vect, method in [
         (
-            "HashingVectorizer (vtext, n_jobs=1)",
+            "HashingVectorizer(n_jobs=1).transform [vtext]",
             vtext.vectorize.HashingVectorizer(),
             "fit_transform",
         ),
         (
-            "HashingVectorizer (vtext, n_jobs=2)",
-            vtext.vectorize.HashingVectorizer(n_jobs=2),
+            "HashingVectorizer(n_jobs=4).transform [vtext]",
+            vtext.vectorize.HashingVectorizer(n_jobs=4),
             "fit_transform",
         ),
-        # (
-        #    "HashingVectorizer (scikit-learn)",
-        #    skt.HashingVectorizer(lowercase=False, norm=None),
-        #    "fit_transform",
-        # ),
-        ("CountVectorizer.fit (vtext)", vtext.vectorize.CountVectorizer(), "fit"),
         (
-            "CountVectorizer.transform (vtext)",
+            "HashingVectorizer().transform [scikit-learn]",
+            skt.HashingVectorizer(lowercase=False, norm=None),
+            "fit_transform",
+        ),
+        (
+            "CountVectorizer(n_jobs=1).fit [vtext]",
+            vtext.vectorize.CountVectorizer(),
+            "fit",
+        ),
+        (
+            "CountVectorizer(n_jobs=4).fit [vtext]",
+            vtext.vectorize.CountVectorizer(n_jobs=4),
+            "fit",
+        ),
+        (
+            "CountVectorizer(n_jobs=1).transform [vtext]",
             vtext.vectorize.CountVectorizer().fit(data),
             "transform",
         ),
-        ("CountVectorizer (vtext)", vtext.vectorize.CountVectorizer(), "fit_transform"),
+        (
+            "CountVectorizer(n_jobs=4).transform [vtext]",
+            vtext.vectorize.CountVectorizer(n_jobs=4).fit(data),
+            "transform",
+        ),
+        (
+            "CountVectorizer().fit_transform [vtext]",
+            vtext.vectorize.CountVectorizer(),
+            "fit_transform",
+        ),
+        (
+            "CountVectorizer().fit_transform [scikit-learn]",
+            skt.CountVectorizer(lowercase=True),
+            "fit_transform",
+        ),
         # (
-        #     "CountVectorizer (scikit-learn)",
-        #     skt.CountVectorizer(lowercase=False),
-        #     "fit_transform",
-        # ),
-        # (
-        #    "CountVectorizer, 4-char ngram (scikit-learn)",
-        #    skt.CountVectorizer(lowercase=False, analyzer="char", ngram_range=(4, 4)),
+        #     "CountVectorizer, 10-char ngram [scikit-learn]",
+        #     skt.CountVectorizer(lowercase=True, analyzer="char", ngram_range=(10, 10)),
+        #     "fit_transform"
         # ),
     ]:
 
@@ -65,7 +84,7 @@ if __name__ == "__main__":
         dt = time() - t0
 
         print(
-            "{:>40}: {:.2f}s [{:.1f} MB/s], shape={}, nnz={}".format(
+            "{:>50}: {:.2f}s [{:.1f} MB/s], shape={}, nnz={}".format(
                 label, dt, dataset_size / dt, X.shape, X.nnz
             )
         )

--- a/benchmarks/bench_vectorizers.py
+++ b/benchmarks/bench_vectorizers.py
@@ -19,18 +19,30 @@ if __name__ == "__main__":
 
     print("# vectorizing {} documents:".format(len(data)))
 
-    for label, vect in [
-        ("HashingVectorizer (vtext, n_jobs=1)", vtext.vectorize.HashingVectorizer()),
+    for label, vect, method in [
+        (
+            "HashingVectorizer (vtext, n_jobs=1)",
+            vtext.vectorize.HashingVectorizer(),
+            "fit_transform",
+        ),
         (
             "HashingVectorizer (vtext, n_jobs=2)",
             vtext.vectorize.HashingVectorizer(n_jobs=2),
+            "fit_transform",
         ),
-        (
-            "HashingVectorizer (scikit-learn)",
-            skt.HashingVectorizer(lowercase=False, norm=None),
-        ),
-        ("CountVectorizer (vtext)", vtext.vectorize.CountVectorizer()),
-        ("CountVectorizer (scikit-learn)", skt.CountVectorizer(lowercase=False)),
+        #(
+        #    "HashingVectorizer (scikit-learn)",
+        #    skt.HashingVectorizer(lowercase=False, norm=None),
+        #    "fit_transform",
+        #),
+        ("CountVectorizer.fit (vtext)", vtext.vectorize.CountVectorizer(), "fit"),
+        ("CountVectorizer.transform (vtext)", vtext.vectorize.CountVectorizer().fit(data), "transform"),
+        ("CountVectorizer (vtext)", vtext.vectorize.CountVectorizer(), "fit_transform"),
+        # (
+        #     "CountVectorizer (scikit-learn)",
+        #     skt.CountVectorizer(lowercase=False),
+        #     "fit_transform",
+        # ),
         # (
         #    "CountVectorizer, 4-char ngram (scikit-learn)",
         #    skt.CountVectorizer(lowercase=False, analyzer="char", ngram_range=(4, 4)),
@@ -39,7 +51,11 @@ if __name__ == "__main__":
 
         t0 = time()
 
-        X = vect.fit_transform(data)
+        X = getattr(vect, method)(data)
+        if not hasattr(X, "shape"):
+            class X():
+                shape = None
+                nnz = None
 
         dt = time() - t0
 

--- a/benchmarks/bench_vectorizers.py
+++ b/benchmarks/bench_vectorizers.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         ),
         # (
         #     "CountVectorizer, 10-char ngram [scikit-learn]",
-        #     skt.CountVectorizer(lowercase=True, analyzer="char", ngram_range=(10, 10)),
+        #     skt.CountVectorizer(analyzer="char", ngram_range=(10, 10)),
         #     "fit_transform"
         # ),
     ]:

--- a/benchmarks/bench_vectorizers.py
+++ b/benchmarks/bench_vectorizers.py
@@ -30,13 +30,17 @@ if __name__ == "__main__":
             vtext.vectorize.HashingVectorizer(n_jobs=2),
             "fit_transform",
         ),
-        #(
+        # (
         #    "HashingVectorizer (scikit-learn)",
         #    skt.HashingVectorizer(lowercase=False, norm=None),
         #    "fit_transform",
-        #),
+        # ),
         ("CountVectorizer.fit (vtext)", vtext.vectorize.CountVectorizer(), "fit"),
-        ("CountVectorizer.transform (vtext)", vtext.vectorize.CountVectorizer().fit(data), "transform"),
+        (
+            "CountVectorizer.transform (vtext)",
+            vtext.vectorize.CountVectorizer().fit(data),
+            "transform",
+        ),
         ("CountVectorizer (vtext)", vtext.vectorize.CountVectorizer(), "fit_transform"),
         # (
         #     "CountVectorizer (scikit-learn)",
@@ -53,7 +57,8 @@ if __name__ == "__main__":
 
         X = getattr(vect, method)(data)
         if not hasattr(X, "shape"):
-            class X():
+
+            class X:
                 shape = None
                 nnz = None
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -92,8 +92,9 @@ pub struct _CountVectorizerWrapper {
 #[pymethods]
 impl _CountVectorizerWrapper {
     #[new]
-    fn new(obj: &PyRawObject) {
-        let estimator = vtext::vectorize::CountVectorizer::new();
+    #[args(n_jobs = 1)]
+    fn new(obj: &PyRawObject, n_jobs: usize) {
+        let estimator = vtext::vectorize::CountVectorizer::new().n_jobs(n_jobs);
         obj.init(_CountVectorizerWrapper { inner: estimator });
     }
 

--- a/python/vtext/tests/test_vectorize.py
+++ b/python/vtext/tests/test_vectorize.py
@@ -37,16 +37,6 @@ def test_hashing_vectorizer():
     assert_array_equal(X.indices, X2.indices)
 
 
-def test_hashing_vectorizer_params():
-    text = ["some sentence", "a different sentence"]
-    vect = HashingVectorizer(n_jobs=2)
-    vect.fit_transform(text)
-
-    with pytest.raises(ValueError, match="n_jobs=-1 must be a integer >= 1"):
-        vect = HashingVectorizer(n_jobs=-1)
-        vect.fit_transform(text)
-
-
 @pytest.mark.parametrize("Estimator", [HashingVectorizer])
 def test_pickle_vectorizers(Estimator):
 
@@ -55,3 +45,16 @@ def test_pickle_vectorizers(Estimator):
     out = pickle.dumps(vect)
 
     pickle.loads(out)
+
+
+@pytest.mark.parametrize("Estimator", [HashingVectorizer, CountVectorizer])
+def test_vectorizers_n_jobs(Estimator):
+    """Check that parallel feature ingestion works"""
+    text = ["Εν οίδα ότι ουδέν οίδα"]
+
+    vect = Estimator(n_jobs=2)
+    vect.fit(text)
+    vect.transform(text)
+
+    with pytest.raises(ValueError, match="n_jobs=0 must be a integer >= 1"):
+        Estimator(n_jobs=0).fit(text)

--- a/python/vtext/vectorize.py
+++ b/python/vtext/vectorize.py
@@ -247,6 +247,9 @@ class CountVectorizer(BaseEstimator):
         if self.analyzer != "word":
             raise NotImplementedError
 
+        if not isinstance(self.n_jobs, int) or self.n_jobs < 1:
+            raise ValueError("n_jobs={} must be a integer >= 1".format(self.n_jobs))
+
     def fit(self, raw_documents, y=None):
         """Learn a vocabulary dictionary of all tokens in the raw documents.
 
@@ -259,6 +262,7 @@ class CountVectorizer(BaseEstimator):
         -------
         self
         """
+        self._validate_params()
         self._vect = _lib._CountVectorizerWrapper(self.n_jobs)
         self._vect.fit(raw_documents)
         return self

--- a/python/vtext/vectorize.py
+++ b/python/vtext/vectorize.py
@@ -190,6 +190,11 @@ class CountVectorizer(BaseEstimator):
         If True, all non zero counts are set to 1. This is useful for discrete
         probabilistic models that model binary events rather than integer
         counts.
+    n_jobs : int, default=1
+        number of threads to use for parallel feature extraction. n_jobs > 1,
+        is faster, but uses more memory.
+
+        Note: currently any value n_jobs > 1 will use all available cores.
 
     dtype : type, optional
         Type of the matrix returned by fit_transform() or transform().
@@ -225,9 +230,10 @@ class CountVectorizer(BaseEstimator):
 
     """
 
-    def __init__(self, *, analyzer="word", binary=False, dtype=np.int64):
+    def __init__(self, *, analyzer="word", binary=False, n_jobs=1, dtype=np.int64):
         self.analyzer = analyzer
         self.binary = binary
+        self.n_jobs = n_jobs
         self.dtype = dtype
 
     def _check_vocabulary(self):
@@ -253,7 +259,7 @@ class CountVectorizer(BaseEstimator):
         -------
         self
         """
-        self._vect = _lib._CountVectorizerWrapper()
+        self._vect = _lib._CountVectorizerWrapper(self.n_jobs)
         self._vect.fit(raw_documents)
         return self
 
@@ -284,7 +290,7 @@ class CountVectorizer(BaseEstimator):
         self._validate_params()
         self._validate_vocabulary()
 
-        self._vect = _lib._CountVectorizerWrapper()
+        self._vect = _lib._CountVectorizerWrapper(n_jobs=self.n_jobs)
         indices, indptr, data = self._vect.fit_transform(raw_documents)
         n_features = self._vect.get_n_features()
         X = sp.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, n_features))

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -63,24 +63,22 @@ fn _sort_features(X: &mut CSRArray, vocabulary: &mut HashMap<String, i32>) {
 #[inline]
 fn _sum_duplicates(tf: &mut CSRArray, indices_local: &[i32], nnz: &mut usize) {
     if indices_local.len() > 0 {
-        let mut bucket: i32 = 0;
+        let mut bucket: i32 = 1;
         let mut index_last = indices_local[0];
 
         for index_current in indices_local.iter().skip(1) {
-            bucket += 1;
             if *index_current != index_last {
                 tf.indices.push(index_last as usize);
                 tf.data.push(bucket);
                 *nnz += 1;
                 index_last = *index_current;
-                bucket = 0;
+                bucket = 1;
+            } else {
+                bucket += 1;
             }
         }
         tf.indices
             .push(indices_local[indices_local.len() - 1] as usize);
-        if bucket == 0 {
-            bucket += 1
-        }
         tf.data.push(bucket);
         *nnz += 1;
     }

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -107,25 +107,25 @@ impl CountVectorizer {
     pub fn fit(&mut self, X: &[String]) -> () {
         let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
-        let tokenize = |doc: &str| -> HashSet<String> {
-            let mut _vocab: HashSet<String> = HashSet::new();
+        let tokenize = |X: Vec<&String>| -> HashSet<String> {
+            let mut _vocab: HashSet<String> = HashSet::with_capacity(1000);
 
-            let tokens = tokenizer.tokenize(&doc);
+            for doc in X {
+                let doc = doc.to_ascii_lowercase();
+                let tokens = tokenizer.tokenize(&doc);
 
-            for token in tokens {
-                match _vocab.get(token) {
-                    Some(_id) => {},
-                    None => {
+                for token in tokens {
+                    if !_vocab.contains(token) {
                         _vocab.insert(token.to_string());
-                    }
-                };
+                    };
+                }
             }
             _vocab
         };
 
         let pipe = X.par_iter()
-                     .map(|doc| doc.to_ascii_lowercase())
-                     .flat_map(|doc| tokenize(&doc));
+                     .chunks(4)
+                     .flat_map(tokenize);
 
         let mut vocabulary : HashSet<String> = pipe.collect();
     }

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -107,7 +107,7 @@ impl CountVectorizer {
     pub fn fit(&mut self, X: &[String]) -> () {
         let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
-        let tokenize = |X: Vec<&String>| -> HashSet<String> {
+        let tokenize = |X: &[String]| -> HashSet<String> {
             let mut _vocab: HashSet<String> = HashSet::with_capacity(1000);
 
             for doc in X {
@@ -123,9 +123,11 @@ impl CountVectorizer {
             _vocab
         };
 
-        let pipe = X.par_iter()
-                     .chunks(4)
-                     .flat_map(tokenize);
+        //let vocabulary = tokenize(X);
+        
+
+        let pipe = X.par_chunks(X.len() / 4)
+                    .flat_map(tokenize);
 
         let mut vocabulary : HashSet<String> = pipe.collect();
     }

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -107,17 +107,27 @@ impl CountVectorizer {
     pub fn fit(&mut self, X: &[String]) -> () {
         let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
-        let tokenize = |doc: &str| -> Vec<String> {
-            tokenizer.tokenize(&doc).map(|tok| tok.to_string()).collect()
+        let tokenize = |doc: &str| -> HashSet<String> {
+            let mut _vocab: HashSet<String> = HashSet::new();
+
+            let tokens = tokenizer.tokenize(&doc);
+
+            for token in tokens {
+                match _vocab.get(token) {
+                    Some(_id) => {},
+                    None => {
+                        _vocab.insert(token.to_string());
+                    }
+                };
+            }
+            _vocab
         };
 
         let pipe = X.par_iter()
                      .map(|doc| doc.to_ascii_lowercase())
                      .flat_map(|doc| tokenize(&doc));
 
-        let mut vocabulary : Vec<String> = pipe.collect::<Vec<String>>();
-        vocabulary.sort_unstable();
-        vocabulary.dedup();
+        let mut vocabulary : HashSet<String> = pipe.collect();
     }
 
     /// Transform

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -26,7 +26,7 @@ let X = vectorizer.fit_transform(&documents);
 use crate::math::CSRArray;
 use crate::tokenize;
 use crate::tokenize::Tokenizer;
-use hashbrown::HashMap;
+use hashbrown::{HashMap,HashSet};
 use ndarray::Array;
 use rayon::prelude::*;
 use sprs::CsMat;
@@ -103,7 +103,17 @@ impl CountVectorizer {
     ///
     /// This lists the vocabulary
     pub fn fit(&mut self, X: &[String]) -> () {
-        self._fit_transform(X, false);
+        let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
+
+        let tokenize = |doc: &str| -> Vec<String> {
+            tokenizer.tokenize(&doc).map(|tok| tok.to_string()).collect()
+        };
+
+        let pipe = X.iter()
+                     .map(|doc| doc.to_ascii_lowercase())
+                     .flat_map(|doc| tokenize(&doc));
+
+        let vocabulary : HashSet<String> = pipe.collect();
     }
 
     /// Transform

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -108,7 +108,7 @@ impl CountVectorizer {
             lowercase: true,
             token_pattern: String::from(TOKEN_PATTERN_DEFAULT),
             vocabulary: HashMap::with_capacity_and_hasher(1000, Default::default()),
-            _n_jobs: 1
+            _n_jobs: 1,
         }
     }
 
@@ -149,14 +149,13 @@ impl CountVectorizer {
         if self._n_jobs == 1 {
             vocabulary = tokenize(X);
         } else if self._n_jobs > 1 {
-            let chunk_size = cmp::max(X.len() / 4, 1);
+            let chunk_size = cmp::max(X.len() / (self._n_jobs * 4), 1);
 
             let pipe = X.par_chunks(chunk_size).flat_map(tokenize);
             vocabulary = pipe.collect();
         } else {
             panic!("n_jobs={} must be > 0", self._n_jobs);
         }
-
 
         if vocabulary.len() > 0 {
             self.vocabulary = sorted(vocabulary.iter())
@@ -182,7 +181,6 @@ impl CountVectorizer {
 
         let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
-
         let tokenize_map = |doc: &str| -> Vec<i32> {
             // Closure to tokenize a document and returns hash indices for each token
 
@@ -204,7 +202,7 @@ impl CountVectorizer {
             pipe = Box::new(
                 X.iter()
                     .map(|doc| doc.to_ascii_lowercase())
-                    .map(|doc| tokenize_map(&doc))
+                    .map(|doc| tokenize_map(&doc)),
             );
         } else if self._n_jobs > 1 {
             pipe = Box::new(
@@ -212,7 +210,7 @@ impl CountVectorizer {
                     .map(|doc| doc.to_ascii_lowercase())
                     .map(|doc| tokenize_map(&doc))
                     .collect::<Vec<Vec<i32>>>()
-                    .into_iter()
+                    .into_iter(),
             );
         } else {
             panic!("n_jobs={} must be > 0", self._n_jobs);

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -26,7 +26,7 @@ let X = vectorizer.fit_transform(&documents);
 use crate::math::CSRArray;
 use crate::tokenize;
 use crate::tokenize::Tokenizer;
-use hashbrown::{HashMap,HashSet};
+use hashbrown::{HashMap, HashSet};
 use ndarray::Array;
 use rayon::prelude::*;
 use sprs::CsMat;
@@ -89,8 +89,6 @@ pub struct CountVectorizer {
 
 pub enum Vectorizer {}
 
-
-
 impl CountVectorizer {
     /// Initialize a CountVectorizer estimator
     pub fn new() -> Self {
@@ -123,17 +121,15 @@ impl CountVectorizer {
             _vocab
         };
 
-        //let vocabulary = tokenize(X);
-        
+        let pipe = X.par_chunks(X.len() / 4).flat_map(tokenize);
 
-        let pipe = X.par_chunks(X.len() / 4)
-                    .flat_map(tokenize);
+        let mut vocabulary: HashSet<String> = pipe.collect();
 
-        let mut vocabulary : HashSet<String> = pipe.collect();
-
-        self.vocabulary = vocabulary.iter().zip((0..vocabulary.len()))
-                                .map(|(tok, idx)| (tok.to_owned(), idx as i32))
-                                .collect();
+        self.vocabulary = vocabulary
+            .iter()
+            .zip((0..vocabulary.len()))
+            .map(|(tok, idx)| (tok.to_owned(), idx as i32))
+            .collect();
     }
 
     /// Transform

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -89,6 +89,8 @@ pub struct CountVectorizer {
 
 pub enum Vectorizer {}
 
+
+
 impl CountVectorizer {
     /// Initialize a CountVectorizer estimator
     pub fn new() -> Self {
@@ -109,11 +111,13 @@ impl CountVectorizer {
             tokenizer.tokenize(&doc).map(|tok| tok.to_string()).collect()
         };
 
-        let pipe = X.iter()
+        let pipe = X.par_iter()
                      .map(|doc| doc.to_ascii_lowercase())
                      .flat_map(|doc| tokenize(&doc));
 
-        let vocabulary : HashSet<String> = pipe.collect();
+        let mut vocabulary : Vec<String> = pipe.collect::<Vec<String>>();
+        vocabulary.sort_unstable();
+        vocabulary.dedup();
     }
 
     /// Transform

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -47,7 +47,6 @@ fn _sort_features(X: &mut CSRArray, vocabulary: &mut HashMap<String, i32>) {
         .map(|(key, val)| (key.clone(), val.clone()))
         .collect();
     vocabulary_sorted.sort_unstable();
-    //vocabulary = vocabulary_sorted.into_iter().collect();
     let mut idx_map: Array<usize, _> = Array::zeros(vocabulary_sorted.len());
     for (idx_new, (_term, idx_old)) in vocabulary_sorted.iter().enumerate() {
         idx_map[*idx_old as usize] = idx_new;
@@ -83,8 +82,8 @@ fn _sum_duplicates(tf: &mut CSRArray, indices_local: &[i32], nnz: &mut usize) {
             bucket += 1
         }
         tf.data.push(bucket);
+        *nnz += 1;
     }
-    *nnz += 1;
 
     tf.indptr.push(*nnz);
 }

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -30,6 +30,21 @@ fn test_count_vectorizer_simple() {
 }
 
 #[test]
+fn test_count_vectorizer_fit_transform() {
+    for documents in &[vec![String::from("cat dog cat")]] {
+        let mut vect = CountVectorizer::new();
+        vect.fit(&documents);
+        let X = vect.transform(&documents);
+
+        let mut vect2 = CountVectorizer::new();
+        let X2 = vect2.fit_transform(&documents);
+        assert_eq!(vect.vocabulary, vect2.vocabulary);
+        println!("{:?}", vect.vocabulary);
+        assert_eq!(X.to_dense(), X2.to_dense());
+    }
+}
+
+#[test]
 fn test_hashing_vectorizer_simple() {
     // Results with scikit-learn 0.20.0
     // >>> vect = HashingVectorizer(norm=None, alternate_sign=False)

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -30,8 +30,29 @@ fn test_count_vectorizer_simple() {
 }
 
 #[test]
+fn test_vectorize_empty_countvectorizer() {
+    let documents = vec!["some tokens".to_string(), "".to_string()];
+
+    let mut vect = CountVectorizer::new();
+    vect.fit_transform(&documents);
+
+    vect.fit(&documents);
+    vect.transform(&documents);
+}
+
+#[test]
+fn test_vectorize_empty_hashingvectorizer() {
+    let documents = vec!["some tokens".to_string(), "".to_string()];
+
+    let vect = HashingVectorizer::new();
+    vect.fit_transform(&documents);
+
+    vect.transform(&documents);
+}
+
+#[test]
 fn test_count_vectorizer_fit_transform() {
-    for documents in &[vec![String::from("cat dog cat")]] {
+    for documents in &[vec!["cat dog cat".to_string()]] {
         let mut vect = CountVectorizer::new();
         vect.fit(&documents);
         let X = vect.transform(&documents);

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -10,23 +10,28 @@ use crate::vectorize::*;
 fn test_count_vectorizer_simple() {
     // Example 1
 
-    let documents = vec![String::from("cat dog cat")];
+    let documents = vec!["cat dog cat".to_string()];
     let mut vect = CountVectorizer::new();
     let X = vect.fit_transform(&documents);
     assert_eq!(X.to_dense(), array![[2, 1]]);
 
     // Example 1
     let documents = vec![
-        String::from("the moon in the sky"),
-        String::from("The sky sky sky is blue"),
+        "the moon in the sky".to_string(),
+        "The sky sky sky is blue".to_string(),
     ];
+    let X_ref = array![[0, 1, 0, 1, 1, 2], [1, 0, 1, 0, 3, 1]];
 
     let mut vect = CountVectorizer::new();
+
+    let X = vect.fit_transform(&documents);
+    assert_eq!(X.to_dense().shape(), X_ref.shape());
+    assert_eq!(X.to_dense(), X_ref);
+
     vect.fit(&documents);
     let X = vect.transform(&documents);
-
-    assert_eq!(X.to_dense().shape(), [2, 6]);
-    assert_eq!(X.to_dense(), array![[0, 1, 0, 1, 1, 2], [1, 0, 1, 0, 3, 1]])
+    assert_eq!(X.to_dense().shape(), X_ref.shape());
+    assert_eq!(X.to_dense(), X_ref);
 }
 
 #[test]


### PR DESCRIPTION
Follow up on #20 

This adds parallel token counting in `CountVectorizer` using rayon. Only the two-step ingestion is parallelized, i.e.,
 1. In a first pass, extract vocabulary from the corpus
     ```py
     vect = CountVectorizer().fit(data)
     ```
 2. In a second pass, extract tokens from the corpus given an existing vocabulary
     ```py
     X = vect.transform(data)
     ```

The one-pass ingestion currently done with `CountVectorizer.fit_transform` is still single threaded. There the problem is more difficult as the vocabulary needs to be shared between threads as it is constructed and tokens extracted. The two pass ingestion will typically be faster starting from 4 CPU cores (cf benchmarks) below but its limitations is that it requires,
 - loading the data twice (or alternatively keeping it all in memory)
 - it loads all the processed tokens in memory when `n_jobs>1` are used.

A known bug is that for `n_jobs>1` all CPU cores will be used irrespective of `n_jobs` value.

In the future, it there we should optionally allow two pass ingestion for `fit_transform` as well.

**Benchmarks**

```
benchmarks/bench_vectorizers.py 
# vectorizing 19924 documents:
     HashingVectorizer(n_jobs=1).transform [vtext]: 1.05s [86.7 MB/s], shape=(19924, 1048576), nnz=3961670
     HashingVectorizer(n_jobs=4).transform [vtext]: 0.30s [304.7 MB/s], shape=(19924, 1048576), nnz=3961670
      HashingVectorizer().transform [scikit-learn]: 5.24s [17.4 MB/s], shape=(19924, 1048576), nnz=4177915
             CountVectorizer(n_jobs=1).fit [vtext]: 0.88s [103.7 MB/s], shape=None, nnz=None
             CountVectorizer(n_jobs=4).fit [vtext]: 0.40s [226.8 MB/s], shape=None, nnz=None
       CountVectorizer(n_jobs=1).transform [vtext]: 1.10s [82.5 MB/s], shape=(19924, 208706), nnz=3962338
       CountVectorizer(n_jobs=4).transform [vtext]: 0.32s [287.1 MB/s], shape=(19924, 208706), nnz=3962338
           CountVectorizer().fit_transform [vtext]: 1.31s [69.5 MB/s], shape=(19924, 208706), nnz=3962338
    CountVectorizer().fit_transform [scikit-learn]: 6.24s [14.6 MB/s], shape=(19924, 208706), nnz=3962338
``` 
(in scikit-learn fit, transform, and fit_transform takes a comparable time for CountVectorizer)