### PR TITLE
Update to PyO3 0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: dependencies
           command: |
             python3.7 -m pip install tox
-            rustup default nightly-2019-02-28
+            rustup default nightly-2019-06-04
             rustup target add x86_64-unknown-linux-musl
       - run:
           name: build-wheels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,8 @@ jobs:
                 "$PYBIN" -m pip uninstall -y vtext
                 cd /tmp/
                 "$PYBIN" -m pip install --pre --no-index --find-links /root/repo/python/dist/ vtext
-                "$PYBIN" -m pytest --pyargs vtext
+                "$PYBIN" -m pip install pytest-faulthandler
+                "$PYBIN" -m pytest -sv --pyargs vtext
                 cd -
             done
       - persist_to_workspace:

--- a/ci/azure/install.cmd
+++ b/ci/azure/install.cmd
@@ -20,11 +20,11 @@ pip --version
 pip install numpy>=1.12.0 scipy>=1.0.0 pytest>=4.0.0 wheel>=0.31.1
 
 curl -sSf -o rustup-init.exe https://win.rustup.rs
-rustup-init.exe -y --default-toolchain nightly-2019-02-28
+rustup-init.exe -y --default-toolchain nightly-2019-06-04
 set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
 
-rustup default nightly-2019-02-28
+rustup default nightly-2019-06-04
 
 @rem Install the build and runtime dependencies of the project.
 cd python/

--- a/ci/azure/install.cmd
+++ b/ci/azure/install.cmd
@@ -24,6 +24,8 @@ rustup-init.exe -y --default-toolchain nightly-2019-02-28
 set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
 
+rustup default nightly-2019-02-28
+
 @rem Install the build and runtime dependencies of the project.
 cd python/
 pip install -r requirements.txt

--- a/ci/azure/install.cmd
+++ b/ci/azure/install.cmd
@@ -31,6 +31,8 @@ cd python/
 pip install -r requirements.txt
 python setup.py bdist_wheel
 
+pip install pytest-faulthandler
+
 @rem Install the generated wheel package to test it
 pip install --pre --no-index --find-links dist\ vtext
 

--- a/ci/azure/install.sh
+++ b/ci/azure/install.sh
@@ -18,7 +18,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 pip list
 
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2019-02-28
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2019-06-04
 source $HOME/.cargo/env
 
 cd python/

--- a/ci/azure/test_python.cmd
+++ b/ci/azure/test_python.cmd
@@ -5,4 +5,5 @@ call activate %VIRTUALENV%
 mkdir %TMP_FOLDER%
 cd %TMP_FOLDER%
 
-pytest --junitxml=%JUNITXML% --showlocals --durations=20 %PYTEST_ARGS% --pyargs vtext
+set RUST_BACKTRACE=1
+pytest -sv --junitxml=%JUNITXML% --showlocals --pyargs vtext

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -22,7 +22,7 @@ The easiest might be to use docker to setup a build environment,
 .. code::
 
     ./run_docker_env.sh
-    rustup default nightly-2019-02-28-x86_64-unknown-linux-gnu
+    rustup default nightly-2019-06-04
     python3.7 -m pip install -r /src/python/requirements.txt
     cd /src/python && python3.7 setup.py install
     python3.7 -m pip install pandas conllu

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -14,11 +14,12 @@ vtext = {"path" = "../"}
 rust-stemmers = "1.1.0"
 
 [dependencies.numpy]
-version = "0.5.0"
+git = "https://github.com/kngwyu/rust-numpy.git"
+branch = "release0.6"
 features = ["python3"]
 
 [dependencies.pyo3]
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -8,18 +8,17 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-ndarray = "~0.12.0"
-sprs = "0.6.2"
+ndarray = "0.12"
+sprs = "0.6"
 vtext = {"path" = "../"}
-rust-stemmers = "1.1.0"
+rust-stemmers = "1.1"
 
 [dependencies.numpy]
-git = "https://github.com/kngwyu/rust-numpy.git"
-branch = "release0.6"
+version = "0.6"
 features = ["python3"]
 
 [dependencies.pyo3]
-version = "0.7.0"
+version = "0.7"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -175,10 +175,8 @@ impl UnicodeSegmentTokenizer {
     /// tokens : List[str]
     ///    computed tokens
     fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
-        let list = PyList::empty(py);
-        for token in self.inner.tokenize(x) {
-            list.append(token)?;
-        }
+        let res: Vec<&str> = self.inner.tokenize(x).collect();
+        let list = PyList::new(py, res);
         Ok(list)
     }
 }
@@ -230,10 +228,8 @@ impl VTextTokenizer {
     /// tokens : List[str]
     ///    computed tokens
     fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
-        let list = PyList::empty(py);
-        for token in self.inner.tokenize(x) {
-            list.append(token)?;
-        }
+        let res: Vec<&str> = self.inner.tokenize(x).collect();
+        let list = PyList::new(py, res);
         Ok(list)
     }
 }
@@ -274,10 +270,8 @@ impl RegexpTokenizer {
     /// tokens : List[str]
     ///    computed tokens
     fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
-        let list = PyList::empty(py);
-        for token in self.inner.tokenize(x) {
-            list.append(token)?;
-        }
+        let res: Vec<&str> = self.inner.tokenize(x).collect();
+        let list = PyList::new(py, res);
         Ok(list)
     }
 }
@@ -331,10 +325,8 @@ impl CharacterTokenizer {
     /// tokens : List[str]
     ///    computed tokens
     fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
-        let list = PyList::empty(py);
-        for token in self.inner.tokenize(x) {
-            list.append(token)?;
-        }
+        let res: Vec<&str> = self.inner.tokenize(x).collect();
+        let list = PyList::new(py, res);
         Ok(list)
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -20,7 +20,7 @@ use sprs::CsMat;
 
 use pyo3::exceptions;
 use pyo3::prelude::*;
-use pyo3::types::PyIterator;
+use pyo3::types::{PyIterator, PyList};
 use pyo3::wrap_pyfunction;
 
 use vtext::metrics;
@@ -174,10 +174,12 @@ impl UnicodeSegmentTokenizer {
     /// -------
     /// tokens : List[str]
     ///    computed tokens
-    fn tokenize(&self, py: Python, x: &str) -> PyResult<(Vec<String>)> {
-        let res = self.inner.tokenize(x);
-        let res = res.map(|s| s.to_string()).collect();
-        Ok(res)
+    fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
+        let list = PyList::empty(py);
+        for token in self.inner.tokenize(x) {
+            list.append(token)?;
+        }
+        Ok(list)
     }
 }
 
@@ -227,10 +229,12 @@ impl VTextTokenizer {
     /// -------
     /// tokens : List[str]
     ///    computed tokens
-    fn tokenize(&self, py: Python, x: &str) -> PyResult<(Vec<String>)> {
-        let res = self.inner.tokenize(x);
-        let res = res.map(|s| s.to_string()).collect();
-        Ok(res)
+    fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
+        let list = PyList::empty(py);
+        for token in self.inner.tokenize(x) {
+            list.append(token)?;
+        }
+        Ok(list)
     }
 }
 
@@ -269,11 +273,12 @@ impl RegexpTokenizer {
     /// -------
     /// tokens : List[str]
     ///    computed tokens
-    fn tokenize(&self, py: Python, x: &str) -> PyResult<(Vec<String>)> {
-        // TODO: reduce the number of copies here
-        let res = self.inner.tokenize(x);
-        let res: Vec<String> = res.map(|s| s.to_string()).collect();
-        Ok(res)
+    fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
+        let list = PyList::empty(py);
+        for token in self.inner.tokenize(x) {
+            list.append(token)?;
+        }
+        Ok(list)
     }
 }
 
@@ -325,11 +330,12 @@ impl CharacterTokenizer {
     /// -------
     /// tokens : List[str]
     ///    computed tokens
-    fn tokenize(&self, py: Python, x: &str) -> PyResult<(Vec<String>)> {
-        // TODO: reduce the number of copies here
-        let res = self.inner.tokenize(x);
-        let res: Vec<String> = res.map(|s| s.to_string()).collect();
-        Ok(res)
+    fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<(&'py PyList)> {
+        let list = PyList::empty(py);
+        for token in self.inner.tokenize(x) {
+            list.append(token)?;
+        }
+        Ok(list)
     }
 }
 


### PR DESCRIPTION
This updates to the lastest PyO3, which allows using lifetimes in pymethods. As result tokenization in Python is a bit faster by avoiding string copies.

On master,
```
python3.7 benchmarks/bench_tokenizers.py
 Tokenizing 19924 documents
         Python re.findall(r'\b\w\w+\b', ...): 2.93s [31.0 MB/s, 2450 kWPS]
                RegexpTokenizer(r'\b\w\w+\b'): 1.96s [46.5 MB/s, 3671 kWPS]
   UnicodeSegmentTokenizer(word_bounds=False): 2.97s [30.7 MB/s, 2269 kWPS]
    UnicodeSegmentTokenizer(word_bounds=True): 3.58s [25.4 MB/s, 3182 kWPS]
                         VTextTokenizer('en'): 4.11s [22.1 MB/s, 2467 kWPS]
                        CharacterTokenizer(4): 7.73s [11.8 MB/s, 5927 kWPS]
```
after this PR,
```
# Tokenizing 19924 documents
         Python re.findall(r'\b\w\w+\b', ...): 2.92s [31.2 MB/s, 2460 kWPS]
                RegexpTokenizer(r'\b\w\w+\b'): 1.40s [64.8 MB/s, 5119 kWPS]
   UnicodeSegmentTokenizer(word_bounds=False): 2.48s [36.8 MB/s, 2721 kWPS]
    UnicodeSegmentTokenizer(word_bounds=True): 2.65s [34.3 MB/s, 4292 kWPS]
                         VTextTokenizer('en'): 3.32s [27.4 MB/s, 3053 kWPS]
                        CharacterTokenizer(4): 4.47s [20.4 MB/s, 10252 kWPS]
```