### PR TITLE
API Set parameters with the builder pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ sprs = "0.6.3"
 unicode-segmentation = "1.2.1"
 hashbrown = { version = "0.3", features = ["rayon"] }
 rayon = "1.0"
+derive_builder = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,3 @@ sprs = "0.6.3"
 unicode-segmentation = "1.2.1"
 hashbrown = { version = "0.3", features = ["rayon"] }
 rayon = "1.0"
-derive_builder = "0.7"

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -7,7 +7,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
-use vtext::tokenize::Tokenizer;
+use vtext::tokenize::*;
 
 /// __init__(self, word_bounds=True)
 ///
@@ -31,7 +31,10 @@ impl UnicodeSegmentTokenizer {
     #[new]
     #[args(word_bounds = true)]
     fn new(obj: &PyRawObject, word_bounds: bool) {
-        let tokenizer = vtext::tokenize::UnicodeSegmentTokenizer::new(word_bounds);
+        let tokenizer = vtext::tokenize::UnicodeSegmentTokenizerParams::default()
+              .word_bounds(word_bounds)
+              .build()
+              .unwrap();
 
         obj.init(UnicodeSegmentTokenizer {
             word_bounds: word_bounds,
@@ -85,7 +88,11 @@ pub struct VTextTokenizer {
 impl VTextTokenizer {
     #[new]
     fn new(obj: &PyRawObject, lang: String) {
-        let tokenizer = vtext::tokenize::VTextTokenizer::new(&lang);
+        let tokenizer = vtext::tokenize::VTextTokenizerParams::default()
+            .lang(&lang)
+            .build()
+            .unwrap();
+
         obj.init(VTextTokenizer {
             lang: lang,
             inner: tokenizer,
@@ -126,7 +133,10 @@ impl RegexpTokenizer {
     #[new]
     #[args(pattern = "\"\\\\b\\\\w\\\\w+\\\\b\"")]
     fn new(obj: &PyRawObject, pattern: &str) {
-        let inner = vtext::tokenize::RegexpTokenizer::new(pattern.to_owned());
+        let inner = vtext::tokenize::RegexpTokenizerParams::default()
+            .pattern(pattern)
+            .build()
+            .unwrap();
 
         obj.init(RegexpTokenizer {
             pattern: pattern.to_string(),
@@ -181,7 +191,10 @@ impl CharacterTokenizer {
     #[new]
     #[args(window_size = 4)]
     fn new(obj: &PyRawObject, window_size: usize) {
-        let inner = vtext::tokenize::CharacterTokenizer::new(window_size);
+        let inner = vtext::tokenize::CharacterTokenizerParams::default()
+            .window_size(window_size)
+            .build()
+            .unwrap();
 
         obj.init(CharacterTokenizer {
             window_size: window_size,

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -32,9 +32,9 @@ impl UnicodeSegmentTokenizer {
     #[args(word_bounds = true)]
     fn new(obj: &PyRawObject, word_bounds: bool) {
         let tokenizer = vtext::tokenize::UnicodeSegmentTokenizerParams::default()
-              .word_bounds(word_bounds)
-              .build()
-              .unwrap();
+            .word_bounds(word_bounds)
+            .build()
+            .unwrap();
 
         obj.init(UnicodeSegmentTokenizer {
             word_bounds: word_bounds,

--- a/python/src/vectorize.rs
+++ b/python/src/vectorize.rs
@@ -81,10 +81,10 @@ impl _CountVectorizerWrapper {
     fn new(obj: &PyRawObject, n_jobs: usize) {
         let tokenizer = vtext::tokenize::RegexpTokenizer::default();
         let estimator = vtext::vectorize::CountVectorizerParams::default()
-           .tokenizer(tokenizer.clone())
-           .n_jobs(n_jobs)
-           .build()
-           .unwrap();
+            .tokenizer(tokenizer.clone())
+            .n_jobs(n_jobs)
+            .build()
+            .unwrap();
         obj.init(_CountVectorizerWrapper { inner: estimator });
     }
 

--- a/python/src/vectorize.rs
+++ b/python/src/vectorize.rs
@@ -48,8 +48,12 @@ impl _HashingVectorizerWrapper {
     #[new]
     #[args(n_jobs = 1)]
     fn new(obj: &PyRawObject, n_jobs: usize) {
-        let tokenizer = vtext::tokenize::RegexpTokenizer::new("\\b\\w\\w+\\b".to_string());
-        let estimator = vtext::vectorize::HashingVectorizer::new(tokenizer).n_jobs(n_jobs);
+        let tokenizer = vtext::tokenize::RegexpTokenizer::default();
+        let estimator = vtext::vectorize::HashingVectorizerParams::default()
+            .tokenizer(tokenizer.clone())
+            .n_jobs(n_jobs)
+            .build()
+            .unwrap();
 
         obj.init(_HashingVectorizerWrapper { inner: estimator });
     }
@@ -75,8 +79,12 @@ impl _CountVectorizerWrapper {
     #[new]
     #[args(n_jobs = 1)]
     fn new(obj: &PyRawObject, n_jobs: usize) {
-        let tokenizer = vtext::tokenize::RegexpTokenizer::new("\\b\\w\\w+\\b".to_string());
-        let estimator = vtext::vectorize::CountVectorizer::new(tokenizer).n_jobs(n_jobs);
+        let tokenizer = vtext::tokenize::RegexpTokenizer::default();
+        let estimator = vtext::vectorize::CountVectorizerParams::default()
+           .tokenizer(tokenizer.clone())
+           .n_jobs(n_jobs)
+           .build()
+           .unwrap();
         obj.init(_CountVectorizerWrapper { inner: estimator });
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,27 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(PartialEq, Debug)]
+pub enum VTextError {
+    SomeError,
+}
+
+impl VTextError {
+    fn descr(&self) -> &str {
+        match *self {
+            VTextError::SomeError => "Some error message",
+        }
+    }
+}
+
+impl Error for VTextError {
+    fn description(&self) -> &str {
+        self.descr()
+    }
+}
+
+impl fmt::Display for VTextError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.descr().fmt(f)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,6 @@ extern crate sprs;
 #[macro_use]
 extern crate itertools;
 extern crate rayon;
-#[macro_use]
-extern crate derive_builder;
 
 pub mod errors;
 mod math;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ extern crate rayon;
 #[macro_use]
 extern crate derive_builder;
 
+pub mod errors;
 mod math;
 pub mod metrics;
 pub mod tokenize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ A simple tokenization example can be found below,
 ```rust
 extern crate vtext;
 
-use vtext::tokenize::{VTextTokenizer,Tokenizer};
+use vtext::tokenize::{VTextTokenizerParams,Tokenizer};
 
-let tok = VTextTokenizer::new("en");
+let tok = VTextTokenizerParams::default().lang("en").build().unwrap();
 let tokens = tok.tokenize("Flights can't depart after 2:00 pm.");
 
 // returns &["Flights", "ca", "n't", "depart", "after", "2:00", "pm", "."]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ extern crate sprs;
 #[macro_use]
 extern crate itertools;
 extern crate rayon;
+#[macro_use]
+extern crate derive_builder;
 
 mod math;
 pub mod metrics;

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -42,7 +42,7 @@ as "ca", "n't" in English. To address such issues, we apply several additional r
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = VTextTokenizer::new("en");
+let tokenizer = VTextTokenizerParams::default().build().unwrap();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "ca", "n't", "jump", "32.3", "feet", ",", "right", "?"]);
 
@@ -175,11 +175,20 @@ pub struct VTextTokenizer {
     pub lang: String,
 }
 
-impl VTextTokenizer {
-    /// Create a new instance
-    pub fn new(lang: &str) -> VTextTokenizer {
-        let lang_valid = match lang {
-            "en" | "fr" => lang,
+/// Builder for the VTextTokenizer
+#[derive(Debug, Clone)]
+pub struct VTextTokenizerParams {
+    lang: String
+}
+
+impl VTextTokenizerParams {
+    pub fn lang(&mut self, value: &str) -> VTextTokenizerParams {
+        self.lang = value.to_string();
+        self.clone()
+    }
+    pub fn build(&mut self) -> Result<VTextTokenizer, VTextError> {
+        let lang = match &self.lang[..] {
+            "en" | "fr" => &self.lang[..],
             _ => {
                 // TODO: add some warning message here
                 //println!(
@@ -191,9 +200,18 @@ impl VTextTokenizer {
                 "any"
             }
         };
-        VTextTokenizer {
-            lang: lang_valid.to_string(),
-        }
+        Ok(VTextTokenizer {
+            lang: lang.to_string(),
+        })
+    }
+}
+
+
+
+impl Default for VTextTokenizerParams {
+    /// Create a new instance
+    fn default() -> VTextTokenizerParams {
+        VTextTokenizerParams {lang: "en".to_string()}
     }
 }
 

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -20,7 +20,7 @@ Using a regular expression tokenizer we would get,
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = RegexpTokenizer::new(r"\b\w\w+\b".to_string());
+let tokenizer = RegexpTokenizerParams::default().build().unwrap();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "brown", "fox", "can", "jump", "32", "feet", "right"]);
 ```
@@ -70,12 +70,28 @@ pub struct RegexpTokenizer {
     regexp: Regex,
 }
 
-impl RegexpTokenizer {
-    /// Create a new instance
-    pub fn new(pattern: String) -> RegexpTokenizer {
-        let regexp = Regex::new(&pattern).unwrap();
+/// Builder for the regexp tokenizer
+#[derive(Debug, Clone)]
+pub struct RegexpTokenizerParams {
+    pattern: String,
+}
 
-        RegexpTokenizer { pattern, regexp }
+impl RegexpTokenizerParams {
+    pub fn pattern(&mut self, value: &str) -> RegexpTokenizerParams {
+        self.pattern = value.to_string();
+        self.clone()
+    }
+    pub fn build(&mut self) -> Result<RegexpTokenizer, VTextError> {
+        let pattern = &self.pattern;
+        let regexp = Regex::new(pattern).unwrap();
+        Ok(RegexpTokenizer { pattern: pattern.to_string(), regexp: regexp })
+    }
+}
+
+impl Default for RegexpTokenizerParams {
+    /// Create a new instance
+    fn default () -> RegexpTokenizerParams {
+        RegexpTokenizerParams { pattern : r"\b\w\w+\b".to_string() }
     }
 }
 
@@ -105,14 +121,7 @@ pub struct UnicodeSegmentTokenizer {
     pub word_bounds: bool,
 }
 
-/// Builder for the unicod segmentation tokenizer
-///
-/// This implementation is a thin wrapper around the
-/// `unicode-segmentation` crate
-///
-/// ## References
-///
-/// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
+/// Builder for the unicode segmentation tokenizer
 #[derive(Debug, Clone)]
 pub struct UnicodeSegmentTokenizerParams {
     params: UnicodeSegmentTokenizer,

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -29,7 +29,7 @@ which would remove all punctuation. A more general approach is to apply unicode 
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = UnicodeSegmentTokenizer::default();
+let tokenizer = UnicodeSegmentTokenizerParams::default().build().unwrap();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "can't", "jump", "32.3", "feet", ",", "right", "?"]);
 ```
@@ -50,6 +50,7 @@ assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "ca", "n't", "jump", "
 extern crate regex;
 extern crate unicode_segmentation;
 
+use crate::errors::VTextError;
 use regex::Regex;
 use std::fmt;
 use unicode_segmentation::UnicodeSegmentation;
@@ -99,21 +100,39 @@ impl fmt::Debug for RegexpTokenizer {
 /// ## References
 ///
 /// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
-#[derive(Builder, Debug, Clone)]
-#[builder(setter(into))]
+#[derive(Debug, Clone)]
 pub struct UnicodeSegmentTokenizer {
     pub word_bounds: bool,
 }
 
-impl UnicodeSegmentTokenizer {
-    /// Create a new instance
-    pub fn new(word_bounds: bool) -> UnicodeSegmentTokenizer {
-        UnicodeSegmentTokenizer { word_bounds }
+/// Builder for the unicod segmentation tokenizer
+///
+/// This implementation is a thin wrapper around the
+/// `unicode-segmentation` crate
+///
+/// ## References
+///
+/// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
+#[derive(Debug, Clone)]
+pub struct UnicodeSegmentTokenizerParams {
+    params: UnicodeSegmentTokenizer,
 }
 
-impl Default for UnicodeSegmentTokenizer {
-    fn default() -> UnicodeSegmentTokenizer {
-        UnicodeSegmentTokenizer {word_bounds : true }
+impl UnicodeSegmentTokenizerParams {
+    pub fn word_bounds(&mut self, value: bool) -> UnicodeSegmentTokenizerParams {
+        self.params.word_bounds = value;
+        self.clone()
+    }
+    pub fn build(&mut self) -> Result<UnicodeSegmentTokenizer, VTextError> {
+        Ok(self.params.clone())
+    }
+}
+
+impl Default for UnicodeSegmentTokenizerParams {
+    fn default() -> UnicodeSegmentTokenizerParams {
+        UnicodeSegmentTokenizerParams {
+            params: UnicodeSegmentTokenizer { word_bounds: true },
+        }
     }
 }
 

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -84,20 +84,25 @@ impl RegexpTokenizerParams {
     pub fn build(&mut self) -> Result<RegexpTokenizer, VTextError> {
         let pattern = &self.pattern;
         let regexp = Regex::new(pattern).unwrap();
-        Ok(RegexpTokenizer { pattern: pattern.to_string(), regexp: regexp })
+        Ok(RegexpTokenizer {
+            pattern: pattern.to_string(),
+            regexp: regexp,
+        })
     }
 }
 
 impl Default for RegexpTokenizerParams {
     /// Create a new instance
-    fn default () -> RegexpTokenizerParams {
-        RegexpTokenizerParams { pattern : r"\b\w\w+\b".to_string() }
+    fn default() -> RegexpTokenizerParams {
+        RegexpTokenizerParams {
+            pattern: r"\b\w\w+\b".to_string(),
+        }
     }
 }
 
 impl Default for RegexpTokenizer {
     /// Create a new instance
-    fn default () -> RegexpTokenizer {
+    fn default() -> RegexpTokenizer {
         RegexpTokenizerParams::default().build().unwrap()
     }
 }
@@ -144,8 +149,6 @@ impl UnicodeSegmentTokenizerParams {
     }
 }
 
-
-
 impl Default for UnicodeSegmentTokenizerParams {
     fn default() -> UnicodeSegmentTokenizerParams {
         UnicodeSegmentTokenizerParams {
@@ -156,11 +159,10 @@ impl Default for UnicodeSegmentTokenizerParams {
 
 impl Default for UnicodeSegmentTokenizer {
     /// Create a new instance
-    fn default () -> UnicodeSegmentTokenizer {
+    fn default() -> UnicodeSegmentTokenizer {
         UnicodeSegmentTokenizerParams::default().build().unwrap()
     }
 }
-
 
 impl Tokenizer for UnicodeSegmentTokenizer {
     /// Tokenize a string
@@ -195,7 +197,7 @@ pub struct VTextTokenizer {
 /// Builder for the VTextTokenizer
 #[derive(Debug, Clone)]
 pub struct VTextTokenizerParams {
-    lang: String
+    lang: String,
 }
 
 impl VTextTokenizerParams {
@@ -223,17 +225,18 @@ impl VTextTokenizerParams {
     }
 }
 
-
 impl Default for VTextTokenizerParams {
     /// Create a new instance
     fn default() -> VTextTokenizerParams {
-        VTextTokenizerParams {lang: "en".to_string()}
+        VTextTokenizerParams {
+            lang: "en".to_string(),
+        }
     }
 }
 
 impl Default for VTextTokenizer {
     /// Create a new instance
-    fn default () -> VTextTokenizer {
+    fn default() -> VTextTokenizer {
         VTextTokenizerParams::default().build().unwrap()
     }
 }
@@ -351,10 +354,33 @@ pub struct CharacterTokenizer {
     pub window_size: usize,
 }
 
-impl CharacterTokenizer {
+#[derive(Debug, Clone)]
+pub struct CharacterTokenizerParams {
+    window_size: usize,
+}
+
+impl CharacterTokenizerParams {
+    pub fn window_size(&mut self, value: usize) -> CharacterTokenizerParams {
+        self.window_size = value;
+        self.clone()
+    }
+    pub fn build(&mut self) -> Result<CharacterTokenizer, VTextError> {
+        Ok(CharacterTokenizer {
+            window_size: self.window_size,
+        })
+    }
+}
+
+impl Default for CharacterTokenizerParams {
+    fn default() -> CharacterTokenizerParams {
+        CharacterTokenizerParams { window_size: 4 }
+    }
+}
+
+impl Default for CharacterTokenizer {
     /// Create a new instance
-    pub fn new(window_size: usize) -> CharacterTokenizer {
-        CharacterTokenizer { window_size }
+    fn default() -> CharacterTokenizer {
+        CharacterTokenizerParams::default().build().unwrap()
     }
 }
 

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -66,7 +66,7 @@ pub trait Tokenizer: fmt::Debug {
 ///
 #[derive(Clone)]
 pub struct RegexpTokenizer {
-    pub params : RegexpTokenizerParams,
+    pub params: RegexpTokenizerParams,
     regexp: Regex,
 }
 
@@ -130,13 +130,13 @@ impl fmt::Debug for RegexpTokenizer {
 /// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
 #[derive(Debug, Clone)]
 pub struct UnicodeSegmentTokenizer {
-    pub params: UnicodeSegmentTokenizerParams
+    pub params: UnicodeSegmentTokenizerParams,
 }
 
 /// Builder for the unicode segmentation tokenizer
 #[derive(Debug, Clone)]
 pub struct UnicodeSegmentTokenizerParams {
-    word_bounds: bool
+    word_bounds: bool,
 }
 
 impl UnicodeSegmentTokenizerParams {
@@ -145,15 +145,15 @@ impl UnicodeSegmentTokenizerParams {
         self.clone()
     }
     pub fn build(&mut self) -> Result<UnicodeSegmentTokenizer, VTextError> {
-        Ok(UnicodeSegmentTokenizer { params: self.clone()} )
+        Ok(UnicodeSegmentTokenizer {
+            params: self.clone(),
+        })
     }
 }
 
 impl Default for UnicodeSegmentTokenizerParams {
     fn default() -> UnicodeSegmentTokenizerParams {
-        UnicodeSegmentTokenizerParams {
-            word_bounds: true 
-        }
+        UnicodeSegmentTokenizerParams { word_bounds: true }
     }
 }
 
@@ -191,7 +191,7 @@ impl Tokenizer for UnicodeSegmentTokenizer {
 /// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
 #[derive(Debug, Clone)]
 pub struct VTextTokenizer {
-    pub params: VTextTokenizerParams
+    pub params: VTextTokenizerParams,
 }
 
 /// Builder for the VTextTokenizer
@@ -220,7 +220,9 @@ impl VTextTokenizerParams {
             }
         };
         self.lang = lang.to_string();
-        Ok(VTextTokenizer {params: self.clone() })
+        Ok(VTextTokenizer {
+            params: self.clone(),
+        })
     }
 }
 
@@ -350,7 +352,7 @@ impl Tokenizer for VTextTokenizer {
 /// Character tokenizer
 #[derive(Debug, Clone)]
 pub struct CharacterTokenizer {
-    pub params: CharacterTokenizerParams
+    pub params: CharacterTokenizerParams,
 }
 
 #[derive(Debug, Clone)]

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -29,7 +29,7 @@ which would remove all punctuation. A more general approach is to apply unicode 
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = UnicodeSegmentTokenizer::new(true);
+let tokenizer = UnicodeSegmentTokenizer::default();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "can't", "jump", "32.3", "feet", ",", "right", "?"]);
 ```
@@ -99,7 +99,8 @@ impl fmt::Debug for RegexpTokenizer {
 /// ## References
 ///
 /// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
-#[derive(Debug, Clone)]
+#[derive(Builder, Debug, Clone)]
+#[builder(setter(into))]
 pub struct UnicodeSegmentTokenizer {
     pub word_bounds: bool,
 }
@@ -108,6 +109,11 @@ impl UnicodeSegmentTokenizer {
     /// Create a new instance
     pub fn new(word_bounds: bool) -> UnicodeSegmentTokenizer {
         UnicodeSegmentTokenizer { word_bounds }
+}
+
+impl Default for UnicodeSegmentTokenizer {
+    fn default() -> UnicodeSegmentTokenizer {
+        UnicodeSegmentTokenizer {word_bounds : true }
     }
 }
 

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -20,7 +20,7 @@ Using a regular expression tokenizer we would get,
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = RegexpTokenizerParams::default().build().unwrap();
+let tokenizer = RegexpTokenizer::default();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "brown", "fox", "can", "jump", "32", "feet", "right"]);
 ```
@@ -29,7 +29,7 @@ which would remove all punctuation. A more general approach is to apply unicode 
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = UnicodeSegmentTokenizerParams::default().build().unwrap();
+let tokenizer = UnicodeSegmentTokenizer::default();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "can't", "jump", "32.3", "feet", ",", "right", "?"]);
 ```
@@ -42,7 +42,7 @@ as "ca", "n't" in English. To address such issues, we apply several additional r
 ```rust
 # let s = "The “brown” fox can't jump 32.3 feet, right?";
 # use vtext::tokenize::*;
-let tokenizer = VTextTokenizerParams::default().build().unwrap();
+let tokenizer = VTextTokenizerParams::default().lang("en").build().unwrap();
 let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "ca", "n't", "jump", "32.3", "feet", ",", "right", "?"]);
 
@@ -95,6 +95,13 @@ impl Default for RegexpTokenizerParams {
     }
 }
 
+impl Default for RegexpTokenizer {
+    /// Create a new instance
+    fn default () -> RegexpTokenizer {
+        RegexpTokenizerParams::default().build().unwrap()
+    }
+}
+
 impl Tokenizer for RegexpTokenizer {
     /// Tokenize a string
     fn tokenize<'a>(&'a self, text: &'a str) -> Box<dyn Iterator<Item = &'a str> + 'a> {
@@ -137,6 +144,8 @@ impl UnicodeSegmentTokenizerParams {
     }
 }
 
+
+
 impl Default for UnicodeSegmentTokenizerParams {
     fn default() -> UnicodeSegmentTokenizerParams {
         UnicodeSegmentTokenizerParams {
@@ -144,6 +153,14 @@ impl Default for UnicodeSegmentTokenizerParams {
         }
     }
 }
+
+impl Default for UnicodeSegmentTokenizer {
+    /// Create a new instance
+    fn default () -> UnicodeSegmentTokenizer {
+        UnicodeSegmentTokenizerParams::default().build().unwrap()
+    }
+}
+
 
 impl Tokenizer for UnicodeSegmentTokenizer {
     /// Tokenize a string
@@ -207,11 +224,17 @@ impl VTextTokenizerParams {
 }
 
 
-
 impl Default for VTextTokenizerParams {
     /// Create a new instance
     fn default() -> VTextTokenizerParams {
         VTextTokenizerParams {lang: "en".to_string()}
+    }
+}
+
+impl Default for VTextTokenizer {
+    /// Create a new instance
+    fn default () -> VTextTokenizer {
+        VTextTokenizerParams::default().build().unwrap()
     }
 }
 

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -20,14 +20,16 @@ fn test_regexp_tokenizer() {
 fn test_unicode_tokenizer() {
     let s = "The quick (\"brown\") fox can't jump 32.3 feet, right?";
 
-    let tokenizer = UnicodeSegmentTokenizer { word_bounds: false };
+    let tokenizer = UnicodeSegmentTokenizerBuilder::default()
+                         .word_bounds(false)
+                         .build().unwrap();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &[
         "The", "quick", "brown", "fox", "can't", "jump", "32.3", "feet", "right",
     ];
     assert_eq!(tokens, b);
 
-    let tokenizer = UnicodeSegmentTokenizer { word_bounds: true };
+    let tokenizer = UnicodeSegmentTokenizer::default();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &[
         "The", "quick", "(", "\"", "brown", "\"", ")", "fox", "can't", "jump", "32.3", "feet", ",",

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -41,7 +41,7 @@ fn test_unicode_tokenizer() {
 
 #[test]
 fn test_vtext_tokenizer_all_lang() {
-    let tokenizer = VTextTokenizer::new("en");
+    let tokenizer = VTextTokenizerParams::default().build().unwrap();
 
     for (s, tokens_ref) in [
         // float numbers
@@ -75,7 +75,7 @@ fn test_vtext_tokenizer_all_lang() {
 
 #[test]
 fn test_vtext_tokenizer_en() {
-    let tokenizer = VTextTokenizer::new("en");
+    let tokenizer = VTextTokenizerParams::default().build().unwrap();
 
     for (s, tokens_ref) in [
         ("We can't", vec!["We", "ca", "n't"]),
@@ -92,7 +92,7 @@ fn test_vtext_tokenizer_en() {
 
 #[test]
 fn test_vtext_tokenizer_fr() {
-    let tokenizer = VTextTokenizer::new("fr");
+    let tokenizer = VTextTokenizerParams::default().lang("fr").build().unwrap();
 
     for (s, tokens_ref) in [("l'image", vec!["l'", "image"])].iter() {
         let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
@@ -102,7 +102,7 @@ fn test_vtext_tokenizer_fr() {
 
 #[test]
 fn test_vtext_tokenizer_invalid_lang() {
-    let tokenizer = VTextTokenizer::new("unknown");
+    let tokenizer = VTextTokenizerParams::default().lang("unknown").build().unwrap();
     assert_eq!(tokenizer.lang, "any");
 }
 

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -10,7 +10,7 @@ use crate::tokenize::*;
 fn test_regexp_tokenizer() {
     let s = "fox can't jump 32.3 feet, right?";
 
-    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
+    let tokenizer = RegexpTokenizer::default();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
     assert_eq!(tokens, b);
@@ -30,7 +30,7 @@ fn test_unicode_tokenizer() {
     ];
     assert_eq!(tokens, b);
 
-    let tokenizer = UnicodeSegmentTokenizerParams::default().build().unwrap();
+    let tokenizer = UnicodeSegmentTokenizer::default();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &[
         "The", "quick", "(", "\"", "brown", "\"", ")", "fox", "can't", "jump", "32.3", "feet", ",",
@@ -41,7 +41,7 @@ fn test_unicode_tokenizer() {
 
 #[test]
 fn test_vtext_tokenizer_all_lang() {
-    let tokenizer = VTextTokenizerParams::default().build().unwrap();
+    let tokenizer = VTextTokenizer::default();
 
     for (s, tokens_ref) in [
         // float numbers
@@ -75,7 +75,7 @@ fn test_vtext_tokenizer_all_lang() {
 
 #[test]
 fn test_vtext_tokenizer_en() {
-    let tokenizer = VTextTokenizerParams::default().build().unwrap();
+    let tokenizer = VTextTokenizer::default();
 
     for (s, tokens_ref) in [
         ("We can't", vec!["We", "ca", "n't"]),
@@ -118,6 +118,6 @@ fn test_character_tokenizer() {
 
 #[test]
 fn test_tokenizer_defaults() {
-    let tokenizer = UnicodeSegmentTokenizerParams::default().build().unwrap();
+    let tokenizer = UnicodeSegmentTokenizer::default();
     assert_eq!(tokenizer.word_bounds, true);
 }

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -102,7 +102,10 @@ fn test_vtext_tokenizer_fr() {
 
 #[test]
 fn test_vtext_tokenizer_invalid_lang() {
-    let tokenizer = VTextTokenizerParams::default().lang("unknown").build().unwrap();
+    let tokenizer = VTextTokenizerParams::default()
+        .lang("unknown")
+        .build()
+        .unwrap();
     assert_eq!(tokenizer.lang, "any");
 }
 
@@ -110,7 +113,7 @@ fn test_vtext_tokenizer_invalid_lang() {
 fn test_character_tokenizer() {
     let s = "fox can't";
 
-    let tokenizer = CharacterTokenizer::new(4);
+    let tokenizer = CharacterTokenizer::default();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &["fox ", "ox c", "x ca", " can", "can'", "an't"];
     assert_eq!(tokens, b);

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -106,7 +106,7 @@ fn test_vtext_tokenizer_invalid_lang() {
         .lang("unknown")
         .build()
         .unwrap();
-    assert_eq!(tokenizer.lang, "any");
+    assert_eq!(tokenizer.params.lang, "any");
 }
 
 #[test]
@@ -122,5 +122,5 @@ fn test_character_tokenizer() {
 #[test]
 fn test_tokenizer_defaults() {
     let tokenizer = UnicodeSegmentTokenizer::default();
-    assert_eq!(tokenizer.word_bounds, true);
+    assert_eq!(tokenizer.params.word_bounds, true);
 }

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -10,7 +10,7 @@ use crate::tokenize::*;
 fn test_regexp_tokenizer() {
     let s = "fox can't jump 32.3 feet, right?";
 
-    let tokenizer = RegexpTokenizer::new(r"\b\w\w+\b".to_string());
+    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
     assert_eq!(tokens, b);

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -20,16 +20,17 @@ fn test_regexp_tokenizer() {
 fn test_unicode_tokenizer() {
     let s = "The quick (\"brown\") fox can't jump 32.3 feet, right?";
 
-    let tokenizer = UnicodeSegmentTokenizerBuilder::default()
-                         .word_bounds(false)
-                         .build().unwrap();
+    let tokenizer = UnicodeSegmentTokenizerParams::default()
+        .word_bounds(false)
+        .build()
+        .unwrap();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &[
         "The", "quick", "brown", "fox", "can't", "jump", "32.3", "feet", "right",
     ];
     assert_eq!(tokens, b);
 
-    let tokenizer = UnicodeSegmentTokenizer::default();
+    let tokenizer = UnicodeSegmentTokenizerParams::default().build().unwrap();
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &[
         "The", "quick", "(", "\"", "brown", "\"", ")", "fox", "can't", "jump", "32.3", "feet", ",",
@@ -113,4 +114,10 @@ fn test_character_tokenizer() {
     let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
     let b: &[_] = &["fox ", "ox c", "x ca", " can", "can'", "an't"];
     assert_eq!(tokens, b);
+}
+
+#[test]
+fn test_tokenizer_defaults() {
+    let tokenizer = UnicodeSegmentTokenizerParams::default().build().unwrap();
+    assert_eq!(tokenizer.word_bounds, true);
 }

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -36,8 +36,6 @@ use rayon::prelude::*;
 use sprs::CsMat;
 use std::cmp;
 
-const TOKEN_PATTERN_DEFAULT: &str = r"\b\w\w+\b";
-
 #[cfg(test)]
 mod tests;
 

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -20,9 +20,7 @@ let documents = vec![
     String::from("Another line"),
 ];
 
-let tokenizer = VTextTokenizer::default();
-
-let mut vectorizer = CountVectorizer::new(tokenizer);
+let mut vectorizer = CountVectorizer::<VTextTokenizer>::default();
 let X = vectorizer.fit_transform(&documents);
 // returns a sparse CSR matrix with document-terms counts
 */

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -12,7 +12,7 @@ This module allows computing a sparse document term matrix from a text corpus.
 ```rust
 extern crate vtext;
 
-use vtext::tokenize::{VTextTokenizer,Tokenizer};
+use vtext::tokenize::{VTextTokenizerParams,Tokenizer};
 use vtext::vectorize::CountVectorizer;
 
 let documents = vec![
@@ -20,7 +20,7 @@ let documents = vec![
     String::from("Another line"),
 ];
 
-let tokenizer = VTextTokenizer::new("en");
+let tokenizer = VTextTokenizerParams::default().build().unwrap();
 
 let mut vectorizer = CountVectorizer::new(tokenizer);
 let X = vectorizer.fit_transform(&documents);

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -12,7 +12,7 @@ This module allows computing a sparse document term matrix from a text corpus.
 ```rust
 extern crate vtext;
 
-use vtext::tokenize::{VTextTokenizerParams,Tokenizer};
+use vtext::tokenize::{VTextTokenizer,Tokenizer};
 use vtext::vectorize::CountVectorizer;
 
 let documents = vec![
@@ -20,7 +20,7 @@ let documents = vec![
     String::from("Another line"),
 ];
 
-let tokenizer = VTextTokenizerParams::default().build().unwrap();
+let tokenizer = VTextTokenizer::default();
 
 let mut vectorizer = CountVectorizer::new(tokenizer);
 let X = vectorizer.fit_transform(&documents);

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -157,7 +157,10 @@ fn test_dispatch_tokenizer() {
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 
-    let tokenizer = CharacterTokenizer::new(4);
+    let tokenizer = CharacterTokenizerParams::default()
+        .window_size(3)
+        .build()
+        .unwrap();
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 }

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -146,7 +146,10 @@ fn test_dispatch_tokenizer() {
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 
-    let tokenizer = UnicodeSegmentTokenizer::new(false);
+    let tokenizer = UnicodeSegmentTokenizerParams::default()
+        .word_bounds(false)
+        .build()
+        .unwrap();
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -49,9 +49,8 @@ fn test_vectorize_empty_countvectorizer() {
 #[test]
 fn test_vectorize_empty_hashingvectorizer() {
     let documents = vec!["some tokens".to_string(), "".to_string()];
-    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
 
-    let vect = HashingVectorizer::new(tokenizer);
+    let vect = HashingVectorizer::<RegexpTokenizer>::default();
     vect.fit_transform(&documents);
 
     vect.transform(&documents);
@@ -89,9 +88,7 @@ fn test_hashing_vectorizer_simple() {
         String::from("The sky is blue"),
     ];
 
-    let tokenizer = VTextTokenizerParams::default().build().unwrap();
-
-    let vect = HashingVectorizer::new(tokenizer);
+    let vect = HashingVectorizer::<VTextTokenizer>::default();
     let vect = vect.fit(&documents);
     let X = vect.transform(&documents);
     assert_eq!(X.indptr(), &[0, 4, 8]);
@@ -131,7 +128,10 @@ fn test_empty_dataset() {
     assert_eq!(X.indices(), &[]);
     assert_eq!(X.indptr(), &[0]);
 
-    let vectorizer = HashingVectorizer::new(tokenizer);
+    let vectorizer = HashingVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build()
+        .unwrap();
 
     let X = vectorizer.fit_transform(&documents);
     assert_eq!(X.data(), &[]);
@@ -146,7 +146,10 @@ fn test_dispatch_tokenizer() {
         .tokenizer(tokenizer.clone())
         .build()
         .unwrap();
-    HashingVectorizer::new(tokenizer);
+    HashingVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build()
+        .unwrap();
 
     let tokenizer = UnicodeSegmentTokenizerParams::default()
         .word_bounds(false)
@@ -156,14 +159,20 @@ fn test_dispatch_tokenizer() {
         .tokenizer(tokenizer.clone())
         .build()
         .unwrap();
-    HashingVectorizer::new(tokenizer);
+    HashingVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build()
+        .unwrap();
 
     let tokenizer = RegexpTokenizerParams::default().build().unwrap();
     CountVectorizerParams::default()
         .tokenizer(tokenizer.clone())
         .build()
         .unwrap();
-    HashingVectorizer::new(tokenizer);
+    HashingVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build()
+        .unwrap();
 
     let tokenizer = CharacterTokenizerParams::default()
         .window_size(3)
@@ -173,5 +182,8 @@ fn test_dispatch_tokenizer() {
         .tokenizer(tokenizer.clone())
         .build()
         .unwrap();
-    HashingVectorizer::new(tokenizer);
+    HashingVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build()
+        .unwrap();
 }

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -10,10 +10,9 @@ use crate::vectorize::*;
 #[test]
 fn test_count_vectorizer_simple() {
     // Example 1
-    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
 
     let documents = vec!["cat dog cat".to_string()];
-    let mut vect = CountVectorizer::new(tokenizer.clone());
+    let mut vect = CountVectorizer::default();
 
     let X = vect.fit_transform(&documents);
     assert_eq!(X.to_dense(), array![[2, 1]]);
@@ -24,7 +23,7 @@ fn test_count_vectorizer_simple() {
         "The sky sky sky is blue".to_string(),
     ];
     let X_ref = array![[0, 1, 0, 1, 1, 2], [1, 0, 1, 0, 3, 1]];
-    let mut vect = CountVectorizer::new(tokenizer);
+    let mut vect = CountVectorizer::default();
 
     let X = vect.fit_transform(&documents);
     assert_eq!(X.to_dense().shape(), X_ref.shape());
@@ -40,9 +39,7 @@ fn test_count_vectorizer_simple() {
 fn test_vectorize_empty_countvectorizer() {
     let documents = vec!["some tokens".to_string(), "".to_string()];
 
-    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
-
-    let mut vect = CountVectorizer::new(tokenizer);
+    let mut vect = CountVectorizer::default();
     vect.fit_transform(&documents);
 
     vect.fit(&documents);
@@ -62,13 +59,12 @@ fn test_vectorize_empty_hashingvectorizer() {
 
 #[test]
 fn test_count_vectorizer_fit_transform() {
-    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
     for documents in &[vec!["cat dog cat".to_string()]] {
-        let mut vect = CountVectorizer::new(tokenizer.clone());
+        let mut vect = CountVectorizer::default();
         vect.fit(&documents);
         let X = vect.transform(&documents);
 
-        let mut vect2 = CountVectorizer::new(tokenizer.clone());
+        let mut vect2 = CountVectorizer::default();
         let X2 = vect2.fit_transform(&documents);
         assert_eq!(vect.vocabulary, vect2.vocabulary);
         println!("{:?}", vect.vocabulary);
@@ -125,7 +121,9 @@ fn test_empty_dataset() {
     let documents: Vec<String> = vec![];
 
     let tokenizer = VTextTokenizerParams::default().build().unwrap();
-    let mut vectorizer = CountVectorizer::new(tokenizer.clone());
+    let mut vectorizer = CountVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build();
 
     let X = vectorizer.fit_transform(&documents);
     assert_eq!(X.data(), &[]);
@@ -143,24 +141,32 @@ fn test_empty_dataset() {
 #[test]
 fn test_dispatch_tokenizer() {
     let tokenizer = VTextTokenizerParams::default().build().unwrap();
-    CountVectorizer::new(tokenizer.clone());
+    CountVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build();
     HashingVectorizer::new(tokenizer);
 
     let tokenizer = UnicodeSegmentTokenizerParams::default()
         .word_bounds(false)
         .build()
         .unwrap();
-    CountVectorizer::new(tokenizer.clone());
+    CountVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build();
     HashingVectorizer::new(tokenizer);
 
     let tokenizer = RegexpTokenizerParams::default().build().unwrap();
-    CountVectorizer::new(tokenizer.clone());
+    CountVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build();
     HashingVectorizer::new(tokenizer);
 
     let tokenizer = CharacterTokenizerParams::default()
         .window_size(3)
         .build()
         .unwrap();
-    CountVectorizer::new(tokenizer.clone());
+    CountVectorizerParams::default()
+        .tokenizer(tokenizer.clone())
+        .build();
     HashingVectorizer::new(tokenizer);
 }

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -93,7 +93,7 @@ fn test_hashing_vectorizer_simple() {
         String::from("The sky is blue"),
     ];
 
-    let tokenizer = VTextTokenizer::new("en");
+    let tokenizer = VTextTokenizerParams::default().build().unwrap();
 
     let vect = HashingVectorizer::new(tokenizer);
     let vect = vect.fit(&documents);
@@ -124,7 +124,7 @@ fn test_hashing_vectorizer_simple() {
 fn test_empty_dataset() {
     let documents: Vec<String> = vec![];
 
-    let tokenizer = VTextTokenizer::new("en");
+    let tokenizer = VTextTokenizerParams::default().build().unwrap();
     let mut vectorizer = CountVectorizer::new(tokenizer.clone());
 
     let X = vectorizer.fit_transform(&documents);
@@ -142,7 +142,7 @@ fn test_empty_dataset() {
 
 #[test]
 fn test_dispatch_tokenizer() {
-    let tokenizer = VTextTokenizer::new("en");
+    let tokenizer = VTextTokenizerParams::default().build().unwrap();
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -12,7 +12,7 @@ fn test_count_vectorizer_simple() {
     // Example 1
 
     let documents = vec!["cat dog cat".to_string()];
-    let mut vect = CountVectorizer::default();
+    let mut vect = CountVectorizer::<RegexpTokenizer>::default();
 
     let X = vect.fit_transform(&documents);
     assert_eq!(X.to_dense(), array![[2, 1]]);
@@ -23,7 +23,7 @@ fn test_count_vectorizer_simple() {
         "The sky sky sky is blue".to_string(),
     ];
     let X_ref = array![[0, 1, 0, 1, 1, 2], [1, 0, 1, 0, 3, 1]];
-    let mut vect = CountVectorizer::default();
+    let mut vect = CountVectorizer::<RegexpTokenizer>::default();
 
     let X = vect.fit_transform(&documents);
     assert_eq!(X.to_dense().shape(), X_ref.shape());
@@ -39,7 +39,7 @@ fn test_count_vectorizer_simple() {
 fn test_vectorize_empty_countvectorizer() {
     let documents = vec!["some tokens".to_string(), "".to_string()];
 
-    let mut vect = CountVectorizer::default();
+    let mut vect = CountVectorizer::<RegexpTokenizer>::default();
     vect.fit_transform(&documents);
 
     vect.fit(&documents);
@@ -60,11 +60,11 @@ fn test_vectorize_empty_hashingvectorizer() {
 #[test]
 fn test_count_vectorizer_fit_transform() {
     for documents in &[vec!["cat dog cat".to_string()]] {
-        let mut vect = CountVectorizer::default();
+        let mut vect = CountVectorizer::<RegexpTokenizer>::default();
         vect.fit(&documents);
         let X = vect.transform(&documents);
 
-        let mut vect2 = CountVectorizer::default();
+        let mut vect2 = CountVectorizer::<RegexpTokenizer>::default();
         let X2 = vect2.fit_transform(&documents);
         assert_eq!(vect.vocabulary, vect2.vocabulary);
         println!("{:?}", vect.vocabulary);
@@ -123,7 +123,8 @@ fn test_empty_dataset() {
     let tokenizer = VTextTokenizerParams::default().build().unwrap();
     let mut vectorizer = CountVectorizerParams::default()
         .tokenizer(tokenizer.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let X = vectorizer.fit_transform(&documents);
     assert_eq!(X.data(), &[]);
@@ -143,7 +144,8 @@ fn test_dispatch_tokenizer() {
     let tokenizer = VTextTokenizerParams::default().build().unwrap();
     CountVectorizerParams::default()
         .tokenizer(tokenizer.clone())
-        .build();
+        .build()
+        .unwrap();
     HashingVectorizer::new(tokenizer);
 
     let tokenizer = UnicodeSegmentTokenizerParams::default()
@@ -152,13 +154,15 @@ fn test_dispatch_tokenizer() {
         .unwrap();
     CountVectorizerParams::default()
         .tokenizer(tokenizer.clone())
-        .build();
+        .build()
+        .unwrap();
     HashingVectorizer::new(tokenizer);
 
     let tokenizer = RegexpTokenizerParams::default().build().unwrap();
     CountVectorizerParams::default()
         .tokenizer(tokenizer.clone())
-        .build();
+        .build()
+        .unwrap();
     HashingVectorizer::new(tokenizer);
 
     let tokenizer = CharacterTokenizerParams::default()
@@ -167,6 +171,7 @@ fn test_dispatch_tokenizer() {
         .unwrap();
     CountVectorizerParams::default()
         .tokenizer(tokenizer.clone())
-        .build();
+        .build()
+        .unwrap();
     HashingVectorizer::new(tokenizer);
 }

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -10,7 +10,7 @@ use crate::vectorize::*;
 #[test]
 fn test_count_vectorizer_simple() {
     // Example 1
-    let tokenizer = RegexpTokenizer::new("\\b\\w+\\w\\b".to_string());
+    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
 
     let documents = vec!["cat dog cat".to_string()];
     let mut vect = CountVectorizer::new(tokenizer.clone());
@@ -40,7 +40,7 @@ fn test_count_vectorizer_simple() {
 fn test_vectorize_empty_countvectorizer() {
     let documents = vec!["some tokens".to_string(), "".to_string()];
 
-    let tokenizer = RegexpTokenizer::new("\\b\\w+\\w\\b".to_string());
+    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
 
     let mut vect = CountVectorizer::new(tokenizer);
     vect.fit_transform(&documents);
@@ -52,7 +52,7 @@ fn test_vectorize_empty_countvectorizer() {
 #[test]
 fn test_vectorize_empty_hashingvectorizer() {
     let documents = vec!["some tokens".to_string(), "".to_string()];
-    let tokenizer = RegexpTokenizer::new("\\b\\w+\\w\\b".to_string());
+    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
 
     let vect = HashingVectorizer::new(tokenizer);
     vect.fit_transform(&documents);
@@ -62,7 +62,7 @@ fn test_vectorize_empty_hashingvectorizer() {
 
 #[test]
 fn test_count_vectorizer_fit_transform() {
-    let tokenizer = RegexpTokenizer::new("\\b\\w+\\w\\b".to_string());
+    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
     for documents in &[vec!["cat dog cat".to_string()]] {
         let mut vect = CountVectorizer::new(tokenizer.clone());
         vect.fit(&documents);
@@ -153,7 +153,7 @@ fn test_dispatch_tokenizer() {
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 
-    let tokenizer = RegexpTokenizer::new("\\b\\w+\\w\\b".to_string());
+    let tokenizer = RegexpTokenizerParams::default().build().unwrap();
     CountVectorizer::new(tokenizer.clone());
     HashingVectorizer::new(tokenizer);
 


### PR DESCRIPTION
This refactors the API to enable setting parameters with the builder pattern, e.g.
```rust
let tokenizer = VTextTokenizerParams::default()
     .lang("en")
     .build()
     .unwrap();
```
which in this case is equivalent to `VTextTokenizer::default()`.

Vectorizers can similarly be intialized with,
```rust
let vect = CountVectorizerParams::default()
           .tokenizer(tokenizer.clone())
           .n_jobs(4)
           .build()
           .unwrap();
```
with the default implementations with e.g. `CountVectorizer::<VTextTokenizer>::default()`. The API may still change somewhat in this latter part.

Model parameters are now consistently stored as,
```rust
struct Model {
  params: ModelParams,
  // + weights etc
}
```

I have not used `derive_builder` so far, so this does add some boilerplate in the code.