### PR TITLE
TST Use hypothesis in python tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             for PYBIN in python3.{5,6,7}; do
                 "$PYBIN" -m pip install setuptools setuptools-rust>=0.10.2
                 "$PYBIN" -m pip install numpy==1.15.0 scipy==1.1.0
-                "$PYBIN" -m pip install wheel==0.31.1 auditwheel==2.0.0 pytest
+                "$PYBIN" -m pip install wheel==0.31.1 auditwheel==2.0.0 pytest hypothesis
                 "$PYBIN" setup.py bdist_wheel
             done
             for whl in dist/*.whl; do

--- a/ci/azure/install.cmd
+++ b/ci/azure/install.cmd
@@ -18,7 +18,7 @@ python --version
 pip --version
 
 @rem Use oldest supported numpy and scipy versions for building wheels
-pip install numpy==1.15.0 scipy==1.1.0 pytest>=4.0.0 wheel>=0.31.1
+pip install numpy==1.15.0 scipy==1.1.0 pytest>=4.0.0 wheel>=0.31.1 hypothesis
 
 curl -sSf -o rustup-init.exe https://win.rustup.rs
 rustup-init.exe -y --default-toolchain nightly-2019-06-04

--- a/ci/azure/install.sh
+++ b/ci/azure/install.sh
@@ -13,7 +13,7 @@ python --version
 pip --version
 
 # Use oldest supported numpy, scipy versins for building wheels
-pip install numpy==1.15.0 scipy==1.1.0 pytest>=4.0.0 wheel>=0.31.1
+pip install numpy==1.15.0 scipy==1.1.0 pytest>=4.0.0 wheel>=0.31.1 hypothesis
 
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"

--- a/python/vtext/tests/test_tokenize.py
+++ b/python/vtext/tests/test_tokenize.py
@@ -5,10 +5,15 @@
 # modified, or distributed except according to those terms.
 
 import pytest
+import hypothesis
+import hypothesis.strategies as st
 
-from vtext.tokenize import UnicodeSegmentTokenizer
-from vtext.tokenize import RegexpTokenizer
-from vtext.tokenize import CharacterTokenizer
+from vtext.tokenize import (
+    UnicodeSegmentTokenizer,
+    RegexpTokenizer,
+    CharacterTokenizer,
+    VTextTokenizer,
+)
 
 
 def test_unicode_segment_tokenize():
@@ -46,3 +51,27 @@ def test_character_tokenizer():
         "can'",
         "an't",
     ]
+
+
+@hypothesis.given(st.text())
+def test_regex_tokenize_any(txt):
+    tokenizer = RegexpTokenizer()
+    tokenizer.tokenize(txt)
+
+
+@hypothesis.given(st.text())
+def test_character_tokenize_any(txt):
+    tokenizer = CharacterTokenizer()
+    tokenizer.tokenize(txt)
+
+
+@hypothesis.given(st.text())
+def test_unicode_segment_tokenize_any(txt):
+    tokenizer = UnicodeSegmentTokenizer()
+    tokenizer.tokenize(txt)
+
+
+@hypothesis.given(st.text())
+def test_vtext_tokenize_any(txt):
+    tokenizer = VTextTokenizer("en")
+    tokenizer.tokenize(txt)


### PR DESCRIPTION
Use [hypothesis](https://hypothesis.readthedocs.io/en/latest/) for tests, in particular to ensure that no panic occurs on uncommon unicode inputs in tokenizers.