### PR TITLE
PY Implement get_params methods for tokenizers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,5 @@ sprs = "0.6.5"
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
 rayon = "1.1"
+dict_derive = "0.1.1"
+pyo3 = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,9 @@ sprs = "0.6.5"
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
 rayon = "1.1"
-dict_derive = "0.1.1"
-pyo3 = "0.7"
+dict_derive = {version = "0.1.1", optional = true}
+pyo3 = {version = "0.7", optional = true}
+
+[features]
+# Additional bindings used from the python wrapper.
+python = ["pyo3", "dict_derive"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 ndarray = "0.12"
 sprs = "0.6"
-vtext = {"path" = "../"}
+vtext = {"path" = "../", features=["python"]}
 rust-stemmers = "1.1"
 
 [dependencies.numpy]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -183,6 +183,7 @@ pub fn edit_distance(
 fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<vectorize::_HashingVectorizerWrapper>()?;
     m.add_class::<vectorize::_CountVectorizerWrapper>()?;
+    m.add_class::<tokenize::BaseTokenizer>()?;
     m.add_class::<tokenize::UnicodeSegmentTokenizer>()?;
     m.add_class::<tokenize::RegexpTokenizer>()?;
     m.add_class::<tokenize::VTextTokenizer>()?;

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -60,6 +60,19 @@ impl UnicodeSegmentTokenizer {
         let list = PyList::new(py, res);
         Ok(list)
     }
+
+
+    /// get_params(self, x)
+    ///
+    /// Get parameters for this estimator.
+    ///
+    /// Returns
+    /// -------
+    /// params : mapping of string to any
+    ///          Parameter names mapped to their values.
+    fn get_params<'py>(&self, py: Python<'py>) -> PyResult<UnicodeSegmentTokenizerParams> {
+        Ok(self.inner.params.clone())
+    }
 }
 
 /// __init__(self, lang)
@@ -117,6 +130,18 @@ impl VTextTokenizer {
         let list = PyList::new(py, res);
         Ok(list)
     }
+
+    /// get_params(self, x)
+    ///
+    /// Get parameters for this estimator.
+    ///
+    /// Returns
+    /// -------
+    /// params : mapping of string to any
+    ///          Parameter names mapped to their values.
+    fn get_params<'py>(&self, py: Python<'py>) -> PyResult<VTextTokenizerParams> {
+        Ok(self.inner.params.clone())
+    }
 }
 
 /// __init__(self, pattern=r'\\b\\w\\w+\\b')
@@ -161,6 +186,19 @@ impl RegexpTokenizer {
         let res: Vec<&str> = self.inner.tokenize(x).collect();
         let list = PyList::new(py, res);
         Ok(list)
+    }
+
+
+    /// get_params(self, x)
+    ///
+    /// Get parameters for this estimator.
+    ///
+    /// Returns
+    /// -------
+    /// params : mapping of string to any
+    ///          Parameter names mapped to their values.
+    fn get_params<'py>(&self, py: Python<'py>) -> PyResult<RegexpTokenizerParams> {
+        Ok(self.inner.params.clone())
     }
 }
 
@@ -219,5 +257,17 @@ impl CharacterTokenizer {
         let res: Vec<&str> = self.inner.tokenize(x).collect();
         let list = PyList::new(py, res);
         Ok(list)
+    }
+
+    /// get_params(self, x)
+    ///
+    /// Get parameters for this estimator.
+    ///
+    /// Returns
+    /// -------
+    /// params : mapping of string to any
+    ///          Parameter names mapped to their values.
+    fn get_params<'py>(&self, py: Python<'py>) -> PyResult<CharacterTokenizerParams> {
+        Ok(self.inner.params.clone())
     }
 }

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -10,8 +10,7 @@ use pyo3::types::PyList;
 use vtext::tokenize::*;
 
 #[pyclass]
-pub struct BaseTokenizer {
-}
+pub struct BaseTokenizer {}
 
 #[pymethods]
 impl BaseTokenizer {
@@ -72,7 +71,6 @@ impl UnicodeSegmentTokenizer {
         let list = PyList::new(py, res);
         Ok(list)
     }
-
 
     /// get_params(self, x)
     ///
@@ -200,7 +198,6 @@ impl RegexpTokenizer {
         let list = PyList::new(py, res);
         Ok(list)
     }
-
 
     /// get_params(self, x)
     ///

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -13,6 +13,13 @@ use vtext::tokenize::*;
 pub struct BaseTokenizer {
 }
 
+#[pymethods]
+impl BaseTokenizer {
+    #[new]
+    fn new(obj: &PyRawObject) {
+        obj.init(BaseTokenizer {});
+    }
+}
 
 /// __init__(self, word_bounds=True)
 ///
@@ -80,7 +87,7 @@ impl UnicodeSegmentTokenizer {
     }
 }
 
-/// __init__(self, lang)
+/// __init__(self, lang="en")
 ///
 /// VText tokenizer
 ///
@@ -145,7 +152,7 @@ impl VTextTokenizer {
     /// -------
     /// params : mapping of string to any
     ///          Parameter names mapped to their values.
-    fn get_params<'py>(&self, py: Python<'py>) -> PyResult<VTextTokenizerParams> {
+    fn get_params<'py>(&self) -> PyResult<VTextTokenizerParams> {
         Ok(self.inner.params.clone())
     }
 }

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -9,6 +9,11 @@ use pyo3::types::PyList;
 
 use vtext::tokenize::*;
 
+#[pyclass]
+pub struct BaseTokenizer {
+}
+
+
 /// __init__(self, word_bounds=True)
 ///
 /// Unicode Segmentation tokenizer
@@ -20,7 +25,7 @@ use vtext::tokenize::*;
 /// References
 /// ----------
 /// - `Unicode® Standard Annex #29 <http://www.unicode.org/reports/tr29/>`_
-#[pyclass]
+#[pyclass(extends=BaseTokenizer)]
 pub struct UnicodeSegmentTokenizer {
     pub word_bounds: bool,
     inner: vtext::tokenize::UnicodeSegmentTokenizer,
@@ -91,7 +96,7 @@ impl UnicodeSegmentTokenizer {
 /// ----------
 ///
 /// - `Unicode® Standard Annex #29 <http://www.unicode.org/reports/tr29/>`_
-#[pyclass]
+#[pyclass(extends=BaseTokenizer)]
 pub struct VTextTokenizer {
     pub lang: String,
     inner: vtext::tokenize::VTextTokenizer,
@@ -100,14 +105,15 @@ pub struct VTextTokenizer {
 #[pymethods]
 impl VTextTokenizer {
     #[new]
-    fn new(obj: &PyRawObject, lang: String) {
+    #[args(lang = "\"en\"")]
+    fn new(obj: &PyRawObject, lang: &str) {
         let tokenizer = vtext::tokenize::VTextTokenizerParams::default()
-            .lang(&lang)
+            .lang(lang)
             .build()
             .unwrap();
 
         obj.init(VTextTokenizer {
-            lang: lang,
+            lang: lang.to_string(),
             inner: tokenizer,
         });
     }
@@ -147,7 +153,7 @@ impl VTextTokenizer {
 /// __init__(self, pattern=r'\\b\\w\\w+\\b')
 ///
 /// Tokenize a document using regular expressions
-#[pyclass]
+#[pyclass(extends=BaseTokenizer)]
 pub struct RegexpTokenizer {
     pub pattern: String,
     inner: vtext::tokenize::RegexpTokenizer,
@@ -218,7 +224,7 @@ impl RegexpTokenizer {
 /// >>> tokenizer.tokenize('fox can\'t')
 /// ['fox ', 'ox c', 'x ca', ' can', 'can\'', 'an\'t']
 ///
-#[pyclass]
+#[pyclass(extends=BaseTokenizer)]
 pub struct CharacterTokenizer {
     pub window_size: usize,
     inner: vtext::tokenize::CharacterTokenizer,

--- a/python/vtext/tests/test_tokenize.py
+++ b/python/vtext/tests/test_tokenize.py
@@ -54,24 +54,43 @@ def test_character_tokenizer():
 
 
 @hypothesis.given(st.text())
-def test_regex_tokenize_any(txt):
-    tokenizer = RegexpTokenizer()
+@pytest.mark.parametrize(
+    "tokenizer",
+    [
+        RegexpTokenizer(),
+        CharacterTokenizer(),
+        UnicodeSegmentTokenizer(),
+        VTextTokenizer("en"),
+        VTextTokenizer("fr"),
+    ],
+)
+def test_tokenize_edge_cases(tokenizer, txt):
     tokenizer.tokenize(txt)
 
+@pytest.mark.parametrize(
+    "tokenizer, expected",
+    [
+        (RegexpTokenizer(), {'pattern': r'\b\w\w+\b'}),
+        (CharacterTokenizer(), {'window_size': 4}),
+        (UnicodeSegmentTokenizer(), {'word_bounds': True}),
+        (VTextTokenizer("en"), {'lang': 'en'}),
+        (VTextTokenizer("fr"), {'lang': 'fr'}),
+    ],
+)
+def test_tokenize_get_params(tokenizer, expected):
+    params = tokenizer.get_params()
+    assert params == expected
 
-@hypothesis.given(st.text())
-def test_character_tokenize_any(txt):
-    tokenizer = CharacterTokenizer()
-    tokenizer.tokenize(txt)
 
-
-@hypothesis.given(st.text())
-def test_unicode_segment_tokenize_any(txt):
-    tokenizer = UnicodeSegmentTokenizer()
-    tokenizer.tokenize(txt)
-
-
-@hypothesis.given(st.text())
-def test_vtext_tokenize_any(txt):
-    tokenizer = VTextTokenizer("en")
-    tokenizer.tokenize(txt)
+@pytest.mark.parametrize(
+    "tokenizer, expected",
+    [
+#        (RegexpTokenizer(),
+        #(CharacterTokenizer(), ""),
+        #(UnicodeSegmentTokenizer(), ""),
+        #(VTextTokenizer("en"), ""),
+        #(VTextTokenizer("fr"), ""),
+    ],
+)
+def test_tokenize_str_repr(tokenizer, expected):
+    assert str(tokenizer) == expected

--- a/python/vtext/tests/test_tokenize.py
+++ b/python/vtext/tests/test_tokenize.py
@@ -18,6 +18,10 @@ from vtext.tokenize import (
 
 TOKENIZERS = [RegexpTokenizer, CharacterTokenizer, UnicodeSegmentTokenizer, VTextTokenizer]
 
+def _pytest_ids(x):
+    if isinstance(x, BaseTokenizer):
+        return x.__class__.__name__
+
 def test_unicode_segment_tokenize():
 
     tokenizer = UnicodeSegmentTokenizer(word_bounds=False)
@@ -65,6 +69,7 @@ def test_character_tokenizer():
         VTextTokenizer("en"),
         VTextTokenizer("fr"),
     ],
+    ids=_pytest_ids
 )
 def test_tokenize_edge_cases(tokenizer, txt):
     tokenizer.tokenize(txt)
@@ -78,24 +83,11 @@ def test_tokenize_edge_cases(tokenizer, txt):
         (VTextTokenizer("en"), {'lang': 'en'}),
         (VTextTokenizer("fr"), {'lang': 'fr'}),
     ],
+    ids=_pytest_ids
 )
 def test_tokenize_get_params(tokenizer, expected):
     params = tokenizer.get_params()
     assert params == expected
-
-
-@pytest.mark.parametrize(
-    "tokenizer, expected",
-    [
-#        (RegexpTokenizer(),
-        #(CharacterTokenizer(), ""),
-        #(UnicodeSegmentTokenizer(), ""),
-        #(VTextTokenizer("en"), ""),
-        #(VTextTokenizer("fr"), ""),
-    ],
-)
-def test_tokenize_str_repr(tokenizer, expected):
-    assert str(tokenizer) == expected
 
 
 @pytest.mark.parametrize('Tokenizer', TOKENIZERS)

--- a/python/vtext/tests/test_tokenize.py
+++ b/python/vtext/tests/test_tokenize.py
@@ -13,14 +13,21 @@ from vtext.tokenize import (
     RegexpTokenizer,
     CharacterTokenizer,
     VTextTokenizer,
-    BaseTokenizer
+    BaseTokenizer,
 )
 
-TOKENIZERS = [RegexpTokenizer, CharacterTokenizer, UnicodeSegmentTokenizer, VTextTokenizer]
+TOKENIZERS = [
+    RegexpTokenizer,
+    CharacterTokenizer,
+    UnicodeSegmentTokenizer,
+    VTextTokenizer,
+]
+
 
 def _pytest_ids(x):
     if isinstance(x, BaseTokenizer):
         return x.__class__.__name__
+
 
 def test_unicode_segment_tokenize():
 
@@ -69,28 +76,29 @@ def test_character_tokenizer():
         VTextTokenizer("en"),
         VTextTokenizer("fr"),
     ],
-    ids=_pytest_ids
+    ids=_pytest_ids,
 )
 def test_tokenize_edge_cases(tokenizer, txt):
     tokenizer.tokenize(txt)
 
+
 @pytest.mark.parametrize(
     "tokenizer, expected",
     [
-        (RegexpTokenizer(), {'pattern': r'\b\w\w+\b'}),
-        (CharacterTokenizer(), {'window_size': 4}),
-        (UnicodeSegmentTokenizer(), {'word_bounds': True}),
-        (VTextTokenizer("en"), {'lang': 'en'}),
-        (VTextTokenizer("fr"), {'lang': 'fr'}),
+        (RegexpTokenizer(), {"pattern": r"\b\w\w+\b"}),
+        (CharacterTokenizer(), {"window_size": 4}),
+        (UnicodeSegmentTokenizer(), {"word_bounds": True}),
+        (VTextTokenizer("en"), {"lang": "en"}),
+        (VTextTokenizer("fr"), {"lang": "fr"}),
     ],
-    ids=_pytest_ids
+    ids=_pytest_ids,
 )
 def test_tokenize_get_params(tokenizer, expected):
     params = tokenizer.get_params()
     assert params == expected
 
 
-@pytest.mark.parametrize('Tokenizer', TOKENIZERS)
+@pytest.mark.parametrize("Tokenizer", TOKENIZERS)
 def test_tokenize_api(Tokenizer):
     assert issubclass(Tokenizer, BaseTokenizer)
     # check that we can initialize it without positional args

--- a/python/vtext/tests/test_tokenize.py
+++ b/python/vtext/tests/test_tokenize.py
@@ -13,8 +13,10 @@ from vtext.tokenize import (
     RegexpTokenizer,
     CharacterTokenizer,
     VTextTokenizer,
+    BaseTokenizer
 )
 
+TOKENIZERS = [RegexpTokenizer, CharacterTokenizer, UnicodeSegmentTokenizer, VTextTokenizer]
 
 def test_unicode_segment_tokenize():
 
@@ -94,3 +96,10 @@ def test_tokenize_get_params(tokenizer, expected):
 )
 def test_tokenize_str_repr(tokenizer, expected):
     assert str(tokenizer) == expected
+
+
+@pytest.mark.parametrize('Tokenizer', TOKENIZERS)
+def test_tokenize_api(Tokenizer):
+    assert issubclass(Tokenizer, BaseTokenizer)
+    # check that we can initialize it without positional args
+    Tokenizer()

--- a/python/vtext/tokenize.py
+++ b/python/vtext/tokenize.py
@@ -12,8 +12,7 @@ from ._lib import CharacterTokenizer
 
 
 __all__ = [
-    "BaseTokenizer"
-    "UnicodeSegmentTokenizer",
+    "BaseTokenizer" "UnicodeSegmentTokenizer",
     "RegexpTokenizer",
     "VTextTokenizer",
     "CharacterTokenizer",

--- a/python/vtext/tokenize.py
+++ b/python/vtext/tokenize.py
@@ -4,6 +4,7 @@
 # <http://apache.org/licenses/LICENSE-2.0>. This file may not be copied,
 # modified, or distributed except according to those terms.
 
+from ._lib import BaseTokenizer
 from ._lib import UnicodeSegmentTokenizer
 from ._lib import RegexpTokenizer
 from ._lib import VTextTokenizer
@@ -11,6 +12,7 @@ from ._lib import CharacterTokenizer
 
 
 __all__ = [
+    "BaseTokenizer"
     "UnicodeSegmentTokenizer",
     "RegexpTokenizer",
     "VTextTokenizer",

--- a/python/vtext/tokenize.py
+++ b/python/vtext/tokenize.py
@@ -12,7 +12,8 @@ from ._lib import CharacterTokenizer
 
 
 __all__ = [
-    "BaseTokenizer" "UnicodeSegmentTokenizer",
+    "BaseTokenizer",
+    "UnicodeSegmentTokenizer",
     "RegexpTokenizer",
     "VTextTokenizer",
     "CharacterTokenizer",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,12 @@ extern crate hashbrown;
 extern crate sprs;
 #[macro_use]
 extern crate itertools;
-extern crate rayon;
 #[cfg(feature = "python")]
 extern crate dict_derive;
+extern crate rayon;
 #[cfg(feature = "python")]
 #[macro_use]
 extern crate pyo3;
-
 
 pub mod errors;
 mod math;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ extern crate hashbrown;
 extern crate sprs;
 #[macro_use]
 extern crate itertools;
-extern crate rayon;
 extern crate dict_derive;
+extern crate rayon;
 #[macro_use]
 extern crate pyo3;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ extern crate sprs;
 #[macro_use]
 extern crate itertools;
 extern crate rayon;
+extern crate dict_derive;
+#[macro_use]
+extern crate pyo3;
 
 pub mod errors;
 mod math;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,13 @@ extern crate hashbrown;
 extern crate sprs;
 #[macro_use]
 extern crate itertools;
-extern crate dict_derive;
 extern crate rayon;
+#[cfg(feature = "python")]
+extern crate dict_derive;
+#[cfg(feature = "python")]
 #[macro_use]
 extern crate pyo3;
+
 
 pub mod errors;
 mod math;

--- a/src/metrics/string.rs
+++ b/src/metrics/string.rs
@@ -285,5 +285,4 @@ mod tests {
         let res = edit_distance("yesterday", "today", 1, false);
         assert_eq!(res, 5.0);
     }
-
 }

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -54,6 +54,7 @@ use crate::errors::VTextError;
 use regex::Regex;
 use std::fmt;
 use unicode_segmentation::UnicodeSegmentation;
+use dict_derive::{FromPyObject, IntoPyObject};
 
 #[cfg(test)]
 mod tests;
@@ -71,7 +72,7 @@ pub struct RegexpTokenizer {
 }
 
 /// Builder for the regexp tokenizer
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
 pub struct RegexpTokenizerParams {
     pattern: String,
 }
@@ -134,7 +135,7 @@ pub struct UnicodeSegmentTokenizer {
 }
 
 /// Builder for the unicode segmentation tokenizer
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
 pub struct UnicodeSegmentTokenizerParams {
     word_bounds: bool,
 }
@@ -195,7 +196,7 @@ pub struct VTextTokenizer {
 }
 
 /// Builder for the VTextTokenizer
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
 pub struct VTextTokenizerParams {
     lang: String,
 }
@@ -355,7 +356,7 @@ pub struct CharacterTokenizer {
     pub params: CharacterTokenizerParams,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
 pub struct CharacterTokenizerParams {
     window_size: usize,
 }

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -51,6 +51,7 @@ extern crate regex;
 extern crate unicode_segmentation;
 
 use crate::errors::VTextError;
+#[cfg(feature = "python")]
 use dict_derive::{FromPyObject, IntoPyObject};
 use regex::Regex;
 use std::fmt;
@@ -72,7 +73,8 @@ pub struct RegexpTokenizer {
 }
 
 /// Builder for the regexp tokenizer
-#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 pub struct RegexpTokenizerParams {
     pattern: String,
 }
@@ -135,7 +137,8 @@ pub struct UnicodeSegmentTokenizer {
 }
 
 /// Builder for the unicode segmentation tokenizer
-#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 pub struct UnicodeSegmentTokenizerParams {
     word_bounds: bool,
 }
@@ -196,7 +199,8 @@ pub struct VTextTokenizer {
 }
 
 /// Builder for the VTextTokenizer
-#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 pub struct VTextTokenizerParams {
     lang: String,
 }
@@ -356,7 +360,8 @@ pub struct CharacterTokenizer {
     pub params: CharacterTokenizerParams,
 }
 
-#[derive(Debug, Clone, FromPyObject, IntoPyObject)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 pub struct CharacterTokenizerParams {
     window_size: usize,
 }

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -51,10 +51,10 @@ extern crate regex;
 extern crate unicode_segmentation;
 
 use crate::errors::VTextError;
+use dict_derive::{FromPyObject, IntoPyObject};
 use regex::Regex;
 use std::fmt;
 use unicode_segmentation::UnicodeSegmentation;
-use dict_derive::{FromPyObject, IntoPyObject};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
This implements the `get_params` methods for all tokenizers, and also makes them all inherit from the base class `vtext.tokenize.BaseTokenizer`.

The rust crate now optionally depends on pyo3 and [dict_derive](https://github.com/gperinazzo/dict-derive).