### PR TITLE
MAINT Make rayon dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ ndarray = "0.12.1"
 sprs = "0.6.5"
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
-rayon = "1.1"
+rayon = {version = "1.1", optional = true}
 dict_derive = {version = "0.1.1", optional = true}
 pyo3 = {version = "0.7", optional = true}
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,8 +10,9 @@ crate-type = ["cdylib"]
 [dependencies]
 ndarray = "0.12"
 sprs = "0.6"
-vtext = {"path" = "../", features=["python"]}
+vtext = {"path" = "../", features=["python", "rayon"]}
 rust-stemmers = "1.1"
+rayon = "1.2"
 
 [dependencies.numpy]
 version = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ extern crate ndarray;
 extern crate dict_derive;
 extern crate hashbrown;
 extern crate itertools;
+#[cfg(feature = "rayon")]
 extern crate rayon;
 extern crate sprs;
 #[cfg(feature = "python")]

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -34,9 +34,9 @@ use itertools::sorted;
 use ndarray::Array;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
+use sprs::CsMat;
 #[cfg(feature = "rayon")]
 use std::cmp;
-use sprs::CsMat;
 
 #[cfg(test)]
 mod tests;
@@ -182,11 +182,13 @@ impl<T: Tokenizer + Sync> CountVectorizer<T> {
         if self.params.n_jobs == 1 {
             vocabulary = tokenize(X);
         } else if self.params.n_jobs > 1 {
-            #[cfg(not(feature = "rayon"))] {
+            #[cfg(not(feature = "rayon"))]
+            {
                 panic!("vtext not built with rayon support; got n_jobs > 1");
             }
 
-            #[cfg(feature = "rayon")] {
+            #[cfg(feature = "rayon")]
+            {
                 let chunk_size = cmp::max(X.len() / (self.params.n_jobs * 4), 1);
                 let pipe = X.par_chunks(chunk_size).flat_map(tokenize);
                 vocabulary = pipe.collect();
@@ -240,11 +242,13 @@ impl<T: Tokenizer + Sync> CountVectorizer<T> {
                     .map(|doc| tokenize_map(&doc)),
             );
         } else if self.params.n_jobs > 1 {
-            #[cfg(not(feature = "rayon"))] {
+            #[cfg(not(feature = "rayon"))]
+            {
                 panic!("vtext not built with rayon support; got n_jobs > 1");
             }
 
-            #[cfg(feature = "rayon")] {
+            #[cfg(feature = "rayon")]
+            {
                 pipe = Box::new(
                     X.par_iter()
                         .map(|doc| doc.to_ascii_lowercase())
@@ -427,11 +431,13 @@ impl<T: Tokenizer + Sync> HashingVectorizer<T> {
                     .map(|doc| tokenize_hash(&doc)),
             );
         } else if self.params.n_jobs > 1 {
-            #[cfg(not(feature = "rayon"))] {
+            #[cfg(not(feature = "rayon"))]
+            {
                 panic!("vtext not built with rayon support; got n_jobs > 1");
             }
 
-            #[cfg(feature = "rayon")] {
+            #[cfg(feature = "rayon")]
+            {
                 // Parallel pipeline. The scaling is reasonably good, however it uses more
                 // memory as all the tokens need to be collected into a Vec
 

--- a/src/vectorize/tests.rs
+++ b/src/vectorize/tests.rs
@@ -187,3 +187,21 @@ fn test_dispatch_tokenizer() {
         .build()
         .unwrap();
 }
+
+#[test]
+#[cfg(feature = "rayon")]
+fn test_vectorizers_n_jobs() {
+    let documents = vec![
+        String::from("the moon in the sky"),
+        String::from("the sky is blue"),
+        String::from("some other text"),
+        String::from("other words"),
+    ];
+
+    let mut vect = CountVectorizerParams::<RegexpTokenizer>::default()
+        .n_jobs(2)
+        .build()
+        .unwrap();
+    assert_eq!(vect.params.n_jobs, 2);
+    let X = vect.fit(&documents);
+}


### PR DESCRIPTION
Make rayon dependency optional. This is in particular a pre-requisite for building this crate for the wasm32  target.