### PR TITLE
BLD Build for the wasm target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,24 @@ jobs:
           name: test
           command: |
             cargo test
+  wasm32:
+    working_directory: ~/repo
+    docker:
+      - image: rust:1.34.0-slim-stretch
+    steps:
+      - run:
+          name: dependencies
+          command: |
+            apt-get update
+            apt-get install -y build-essential git
+            rustup target add wasm32-unknown-unknown
+
+      - checkout
+
+      - run:
+          name: test
+          command: |
+            cargo test --target wasm32-unknown-unknown
 
   python:
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ workflows:
   build:
     jobs:
       - rust-stable
+      - wasm32
       - python
       - lint
       - upload-wheels:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   rust-stable:
     working_directory: ~/repo
     docker:
-      - image: rust:1.34.0-slim-stretch
+      - image: rust:1.38.0-slim-stretch
     steps:
       - run:
           name: dependencies
@@ -24,7 +24,7 @@ jobs:
   wasm32:
     working_directory: ~/repo
     docker:
-      - image: rust:1.34.0-slim-stretch
+      - image: rust:1.38.0-slim-stretch
     steps:
       - run:
           name: dependencies
@@ -50,7 +50,7 @@ jobs:
           name: dependencies
           command: |
             python3.7 -m pip install tox
-            rustup default nightly-2019-09-19
+            rustup default nightly-2019-11-01
       - run:
           name: build-wheels
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: test
           command: |
-            cargo test --target wasm32-unknown-unknown
+            cargo build --target wasm32-unknown-unknown
 
   python:
     working_directory: ~/repo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.4.0"
 seahash = "3.0.6"
 itertools = "0.8"
 ndarray = "0.12.1"
-sprs = {git = "https://github.com/rth/sprs", branch = "vtext-tmp", default-features = false}
+sprs = "0.7.1"
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
 rayon = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.4.0"
 seahash = "3.0.6"
 itertools = "0.8"
 ndarray = "0.12.1"
-sprs = "0.6.5"
+sprs = {git = "https://github.com/rth/sprs", branch = "vtext-tmp", default-features = false}
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
 rayon = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.4.0"
 seahash = "3.0.6"
 itertools = "0.8"
 ndarray = "0.13.0"
-sprs = {git = "https://github.com/rth/sprs", branch = "ndarray-013", default-features = false}
+sprs = {version  = "0.7.1", default-features = false}
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
 rayon = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ regex = "1"
 lazy_static = "1.4.0"
 seahash = "3.0.6"
 itertools = "0.8"
-ndarray = "0.12.1"
-sprs = "0.7.1"
+ndarray = "0.13.0"
+sprs = {git = "https://github.com/rth/sprs", branch = "ndarray-013", default-features = false}
 unicode-segmentation = "1.3.0"
 hashbrown = { version = "0.6.1", features = ["rayon"] }
-rayon = "1.1"
-dict_derive = {version = "0.1.1", optional = true}
-pyo3 = {version = "0.7", optional = true}
+rayon = "1.2"
+dict_derive = {version = "0.2", optional = true}
+pyo3 = {version = "0.8", optional = true}
 
 [features]
 # Additional bindings used from the python wrapper.

--- a/ci/azure/install.cmd
+++ b/ci/azure/install.cmd
@@ -21,11 +21,9 @@ pip --version
 pip install numpy==1.15.0 scipy==1.1.0 pytest>=4.0.0 wheel>=0.31.1 hypothesis
 
 curl -sSf -o rustup-init.exe https://win.rustup.rs
-rustup-init.exe -y --default-toolchain nightly-2019-09-19
+rustup-init.exe -y --default-toolchain nightly-2019-11-01
 set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
-
-rustup default nightly-2019-06-04
 
 @rem Install the build and runtime dependencies of the project.
 cd python/

--- a/ci/azure/install.cmd
+++ b/ci/azure/install.cmd
@@ -25,6 +25,8 @@ rustup-init.exe -y --default-toolchain nightly-2019-11-01
 set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
 
+rustup default nightly-2019-11-01
+
 @rem Install the build and runtime dependencies of the project.
 cd python/
 pip install -r requirements.txt

--- a/ci/azure/install.sh
+++ b/ci/azure/install.sh
@@ -19,7 +19,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 pip list
 
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2019-09-19
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2019-11-01
 source $HOME/.cargo/env
 
 cd python/

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ndarray = "0.13"
-sprs = {git = "https://github.com/rth/sprs", branch = "ndarray-013", default-features = false}
+sprs = {version  = "0.7.1", default-features = false}
 vtext = {"path" = "../", features=["python"]}
 rust-stemmers = "1.1"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -8,17 +8,17 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-ndarray = "0.12"
-sprs = "0.6"
+ndarray = "0.13"
+sprs = {git = "https://github.com/rth/sprs", branch = "ndarray-013", default-features = false}
 vtext = {"path" = "../", features=["python"]}
 rust-stemmers = "1.1"
 
 [dependencies.numpy]
-version = "0.6"
+version = "0.7"
 features = ["python3"]
 
 [dependencies.pyo3]
-version = "0.7"
+version = "0.8"
 
 [features]
 extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
This aims to build vtext for the wasm32 target.

Currently a blocker is the incompatible `rustc-serialize` create scattered though the dependencies. In particular,
 - ndarray <0.13 (required by sprs: will be fixed in https://github.com/vbarrielle/sprs/pull/175)
 - num-complex < 0.2 (used in sprs: will be fixed in https://github.com/vbarrielle/sprs/pull/164)

other issues may be discovered later on..