### PR TITLE
Sentence tokenizers benchmarks

### DIFF
--- a/benchmarks/bench_sentence_tokenizers.py
+++ b/benchmarks/bench_sentence_tokenizers.py
@@ -24,14 +24,8 @@ if __name__ == "__main__":
 
     db = [
         (r"Python re.split('(?<=[!.?])', ...)", regexp_tokenizer),
-        (
-            "UnicodeSentenceTokenizer()",
-            UnicodeSentenceTokenizer().tokenize,
-        ),
-        (
-            "PunctuationTokenizer()",
-            PunctuationTokenizer().tokenize,
-        ),
+        ("UnicodeSentenceTokenizer()", UnicodeSentenceTokenizer().tokenize,),
+        ("PunctuationTokenizer()", PunctuationTokenizer().tokenize,),
     ]
 
     for label, func in db:

--- a/benchmarks/bench_sentence_tokenizers.py
+++ b/benchmarks/bench_sentence_tokenizers.py
@@ -1,0 +1,52 @@
+from time import time
+from glob import glob
+from pathlib import Path
+import re
+
+from vtext.tokenize_sentence import UnicodeSentenceTokenizer, PunctuationTokenizer
+
+base_dir = Path(__file__).parent.parent.resolve()
+
+if __name__ == "__main__":
+    input_files = list(glob(str(base_dir / "data" / "*" / "*")))
+    data = []
+    for file_path in input_files:
+        with open(file_path, "rt") as fh:
+            data.append(fh.read())
+    assert len(data) > 0
+
+    dataset_size = 91  # MB for 20 newsgroup dataset
+
+    print("# Tokenizing {} documents".format(len(data)))
+
+    def regexp_tokenizer(txt):
+        return list(re.split("(?<=[!.?])", txt))
+
+    db = [
+        (r"Python re.split('(?<=[!.?])', ...)", regexp_tokenizer),
+        (
+            "UnicodeSentenceTokenizer()",
+            UnicodeSentenceTokenizer().tokenize,
+        ),
+        (
+            "PunctuationTokenizer()",
+            PunctuationTokenizer().tokenize,
+        ),
+    ]
+
+    for label, func in db:
+        t0 = time()
+
+        out = []
+        for idx, doc in enumerate(data):
+            out.append(func(doc))
+
+        dt = time() - t0
+
+        n_tokens = sum(len(tok) for tok in out)
+
+        print(
+            "{:>45}: {:.2f}s {:.1f} MB/s, {:.0f} sentences".format(
+                label, dt, dataset_size / dt, n_tokens
+            )
+        )


### PR DESCRIPTION
Add benchmarks for sentence tokenizers, including https://github.com/rth/vtext/pull/70 . The current output is,
```
$ python benchmarks/bench_sentence_tokenizers.py 
# Tokenizing 19924 documents
           Python re.split('(?<=[!.?])', ...): 0.73s 124.2 MB/s, 1589555 sentences
                   UnicodeSentenceTokenizer(): 20.05s 4.5 MB/s, 1396894 sentences
                       PunctuationTokenizer(): 8.09s 11.2 MB/s, 1585005 sentences
```

See [`benchmarks/README.md`](https://github.com/rth/vtext/tree/master/benchmarks) for downloading the 20 newsgroups dataset used in benchmarks.


Will merge on green CI to make working on https://github.com/rth/vtext/pull/70 easier cc @joshlk