### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Tokenizers can now be pickled in Python [#73](https://github.com/rth/vtext/pull/73)
 - Only Python 3.6+ is now supported in the Python package.
 - Renamed `UnicodeSegmentTokenizer` to `UnicodeWordTokenizer`.
+- Better error handling. In particular `error::VTextError` is replaced by `error::EstimatorErr`.
 
 ### Contributors
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ndarray = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
 sprs = {version  = "0.7.1", default-features = false}
 unicode-segmentation = "1.6.0"
+thiserror = "1.0"
 hashbrown = { version = "0.7", features = ["rayon"] }
 rayon = {version = "1.3", optional = true}
 dict_derive = {version = "0.2", optional = true}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -14,6 +14,9 @@ extern crate vtext;
 
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
+use pyo3::PyErr;
+use pyo3::exceptions;
+use vtext::errors::EstimatorErr;
 
 mod stem;
 mod tokenize;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -14,9 +14,6 @@ extern crate vtext;
 
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use pyo3::PyErr;
-use pyo3::exceptions;
-use vtext::errors::EstimatorErr;
 
 mod stem;
 mod tokenize;

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -89,7 +89,7 @@ impl UnicodeSegmentTokenizer {
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         let mut params: UnicodeSegmentTokenizerParams = deserialize_params(py, state)?;
-        self.inner = params.build().unwrap();
+        self.inner = params.build()?;
         Ok(())
     }
 }
@@ -119,13 +119,12 @@ pub struct VTextTokenizer {
 impl VTextTokenizer {
     #[new]
     #[args(lang = "\"en\"")]
-    fn new(lang: &str) -> (Self, BaseTokenizer) {
+    fn new(lang: &str) -> PyResult<(Self, BaseTokenizer)> {
         let tokenizer = vtext::tokenize::VTextTokenizerParams::default()
             .lang(lang)
-            .build()
-            .unwrap();
+            .build()?;
 
-        (VTextTokenizer { inner: tokenizer }, BaseTokenizer::new())
+        Ok((VTextTokenizer { inner: tokenizer }, BaseTokenizer::new()))
     }
 
     /// tokenize(self, x)
@@ -165,7 +164,7 @@ impl VTextTokenizer {
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         let mut params: VTextTokenizerParams = deserialize_params(py, state)?;
-        self.inner = params.build().unwrap();
+        self.inner = params.build()?;
         Ok(())
     }
 }
@@ -182,13 +181,12 @@ pub struct RegexpTokenizer {
 impl RegexpTokenizer {
     #[new]
     #[args(pattern = "\"\\\\b\\\\w\\\\w+\\\\b\"")]
-    fn new(pattern: &str) -> (Self, BaseTokenizer) {
+    fn new(pattern: &str) -> PyResult<(Self, BaseTokenizer)> {
         let inner = vtext::tokenize::RegexpTokenizerParams::default()
             .pattern(pattern)
-            .build()
-            .unwrap();
+            .build()?;
 
-        (RegexpTokenizer { inner: inner }, BaseTokenizer::new())
+        Ok((RegexpTokenizer { inner: inner }, BaseTokenizer::new()))
     }
 
     /// tokenize(self, x)
@@ -228,7 +226,7 @@ impl RegexpTokenizer {
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         let mut params: RegexpTokenizerParams = deserialize_params(py, state)?;
-        self.inner = params.build().unwrap();
+        self.inner = params.build()?;
         Ok(())
     }
 }
@@ -258,13 +256,12 @@ pub struct CharacterTokenizer {
 impl CharacterTokenizer {
     #[new]
     #[args(window_size = 4)]
-    fn new(window_size: usize) -> (Self, BaseTokenizer) {
+    fn new(window_size: usize) -> PyResult<(Self, BaseTokenizer)> {
         let inner = vtext::tokenize::CharacterTokenizerParams::default()
             .window_size(window_size)
-            .build()
-            .unwrap();
+            .build()?;
 
-        (CharacterTokenizer { inner: inner }, BaseTokenizer::new())
+        Ok((CharacterTokenizer { inner: inner }, BaseTokenizer::new()))
     }
 
     /// tokenize(self, x)
@@ -304,7 +301,7 @@ impl CharacterTokenizer {
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         let mut params: CharacterTokenizerParams = deserialize_params(py, state)?;
-        self.inner = params.build().unwrap();
+        self.inner = params.build()?;
         Ok(())
     }
 }

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -41,16 +41,15 @@ pub struct UnicodeSegmentTokenizer {
 impl UnicodeSegmentTokenizer {
     #[new]
     #[args(word_bounds = true)]
-    fn new(word_bounds: bool) -> (Self, BaseTokenizer) {
+    fn new(word_bounds: bool) -> PyResult<(Self, BaseTokenizer)> {
         let tokenizer = vtext::tokenize::UnicodeSegmentTokenizerParams::default()
             .word_bounds(word_bounds)
-            .build()
-            .unwrap();
+            .build()?;
 
-        (
+        Ok((
             UnicodeSegmentTokenizer { inner: tokenizer },
             BaseTokenizer::new(),
-        )
+        ))
     }
 
     /// tokenize(self, x)

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -185,7 +185,7 @@ impl RegexpTokenizer {
         let inner = vtext::tokenize::RegexpTokenizerParams::default()
             .pattern(pattern)
             .build()?;
-      
+
         Ok((RegexpTokenizer { inner }, BaseTokenizer::new()))
     }
 
@@ -262,7 +262,6 @@ impl CharacterTokenizer {
             .build()?;
 
         Ok((CharacterTokenizer { inner }, BaseTokenizer::new()))
-
     }
 
     /// tokenize(self, x)

--- a/python/src/tokenize_sentence.rs
+++ b/python/src/tokenize_sentence.rs
@@ -33,15 +33,14 @@ pub struct UnicodeSentenceTokenizer {
 #[pymethods]
 impl UnicodeSentenceTokenizer {
     #[new]
-    fn new() -> (Self, BaseTokenizer) {
-        let tokenizer = vtext::tokenize_sentence::UnicodeSentenceTokenizerParams::default()
-            .build()
-            .unwrap();
+    fn new() -> PyResult<(Self, BaseTokenizer)> {
+        let tokenizer =
+            vtext::tokenize_sentence::UnicodeSentenceTokenizerParams::default().build()?;
 
-        (
+        Ok((
             UnicodeSentenceTokenizer { inner: tokenizer },
             BaseTokenizer::new(),
-        )
+        ))
     }
 
     /// tokenize(self, x)
@@ -81,7 +80,7 @@ impl UnicodeSentenceTokenizer {
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         let mut params: UnicodeSentenceTokenizerParams = deserialize_params(py, state)?;
-        self.inner = params.build().unwrap();
+        self.inner = params.build()?;
         Ok(())
     }
 }
@@ -108,16 +107,15 @@ pub struct PunctuationTokenizer {
 impl PunctuationTokenizer {
     #[new]
     #[args(punctuation = "vecString![\".\", \"!\", \"?\"]")]
-    fn new(punctuation: Vec<String>) -> (Self, BaseTokenizer) {
+    fn new(punctuation: Vec<String>) -> PyResult<(Self, BaseTokenizer)> {
         let tokenizer = vtext::tokenize_sentence::PunctuationTokenizerParams::default()
             .punctuation(punctuation)
-            .build()
-            .unwrap();
+            .build()?;
 
-        (
+        Ok((
             PunctuationTokenizer { inner: tokenizer },
             BaseTokenizer::new(),
-        )
+        ))
     }
 
     /// tokenize(self, x)
@@ -157,7 +155,7 @@ impl PunctuationTokenizer {
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         let mut params: PunctuationTokenizerParams = deserialize_params(py, state)?;
-        self.inner = params.build().unwrap();
+        self.inner = params.build()?;
         Ok(())
     }
 }

--- a/python/src/vectorize.rs
+++ b/python/src/vectorize.rs
@@ -48,15 +48,14 @@ pub struct _HashingVectorizerWrapper {
 impl _HashingVectorizerWrapper {
     #[new]
     #[args(n_jobs = 1)]
-    fn new(n_jobs: usize) -> Self {
+    fn new(n_jobs: usize) -> PyResult<Self> {
         let tokenizer = vtext::tokenize::RegexpTokenizer::default();
         let estimator = vtext::vectorize::HashingVectorizerParams::default()
             .tokenizer(tokenizer.clone())
             .n_jobs(n_jobs)
-            .build()
-            .unwrap();
+            .build()?;
 
-        _HashingVectorizerWrapper { inner: estimator }
+        Ok(_HashingVectorizerWrapper { inner: estimator })
     }
 
     fn transform(&mut self, py: Python, x: PyObject) -> PyResult<PyCsrArray> {
@@ -79,14 +78,14 @@ pub struct _CountVectorizerWrapper {
 impl _CountVectorizerWrapper {
     #[new]
     #[args(n_jobs = 1)]
-    fn new(n_jobs: usize) -> Self {
+    fn new(n_jobs: usize) -> PyResult<Self> {
         let tokenizer = vtext::tokenize::RegexpTokenizer::default();
         let estimator = vtext::vectorize::CountVectorizerParams::default()
             .tokenizer(tokenizer.clone())
             .n_jobs(n_jobs)
-            .build()
-            .unwrap();
-        _CountVectorizerWrapper { inner: estimator }
+            .build()?;
+
+        Ok(_CountVectorizerWrapper { inner: estimator })
     }
 
     fn fit(&mut self, py: Python, x: PyObject) -> PyResult<()> {

--- a/python/vtext/tests/test_tokenize.py
+++ b/python/vtext/tests/test_tokenize.py
@@ -53,6 +53,9 @@ def test_regexp_tokenize():
     tokenizer = RegexpTokenizer()
     assert tokenizer.tokenize("Today, tomorrow") == ["Today", "tomorrow"]
 
+    with pytest.raises(ValueError, match="Invalid regex parameter"):
+        RegexpTokenizer(pattern="(")
+
 
 def test_character_tokenizer():
     tokenizer = CharacterTokenizer()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,20 +1,17 @@
-use std::error::Error;
-use std::fmt;
-use regex;
-use thiserror::Error;
 #[cfg(feature = "python")]
 use pyo3;
-
+use regex;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum EstimatorErr {
     #[error("Invalid paramer: `{0}`")]
     InvalidParams(String),
-    #[error("Invalid regex paramer")]
+    #[error("Invalid regex parameter")]
     RegexErr {
         #[from]
-        source: regex::Error
-    }
+        source: regex::Error,
+    },
 }
 
 #[cfg(feature = "python")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,27 +1,15 @@
 use std::error::Error;
 use std::fmt;
+use regex;
+use thiserror::Error;
 
-#[derive(PartialEq, Debug)]
-pub enum VTextError {
-    SomeError,
-}
-
-impl VTextError {
-    fn descr(&self) -> &str {
-        match *self {
-            VTextError::SomeError => "Some error message",
-        }
-    }
-}
-
-impl Error for VTextError {
-    fn description(&self) -> &str {
-        self.descr()
-    }
-}
-
-impl fmt::Display for VTextError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.descr().fmt(f)
+#[derive(Error, Debug)]
+pub enum EstimatorErr {
+    #[error("Invalid paramer: `{0}`")]
+    InvalidParams(String),
+    #[error("Invalid regex paramer")]
+    RegexErr {
+        #[from]
+        source: regex::Error
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,9 @@ use std::error::Error;
 use std::fmt;
 use regex;
 use thiserror::Error;
+#[cfg(feature = "python")]
+use pyo3;
+
 
 #[derive(Error, Debug)]
 pub enum EstimatorErr {
@@ -11,5 +14,12 @@ pub enum EstimatorErr {
     RegexErr {
         #[from]
         source: regex::Error
+    }
+}
+
+#[cfg(feature = "python")]
+impl From<EstimatorErr> for pyo3::PyErr {
+    fn from(err: EstimatorErr) -> pyo3::PyErr {
+        pyo3::PyErr::new::<pyo3::exceptions::ValueError, _>(format!("{}", err))
     }
 }

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -50,7 +50,7 @@ assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "ca", "n't", "jump", "
 extern crate regex;
 extern crate unicode_segmentation;
 
-use crate::errors::VTextError;
+use crate::errors::EstimatorErr;
 #[cfg(feature = "python")]
 use dict_derive::{FromPyObject, IntoPyObject};
 use regex::Regex;
@@ -85,9 +85,9 @@ impl RegexpTokenizerParams {
         self.pattern = value.to_string();
         self.clone()
     }
-    pub fn build(&mut self) -> Result<RegexpTokenizer, VTextError> {
+    pub fn build(&mut self) -> Result<RegexpTokenizer, EstimatorErr> {
         let pattern = &self.pattern;
-        let regexp = Regex::new(pattern).unwrap();
+        let regexp = Regex::new(pattern)?;
         Ok(RegexpTokenizer {
             params: self.clone(),
             regexp,
@@ -149,7 +149,7 @@ impl UnicodeSegmentTokenizerParams {
         self.word_bounds = value;
         self.clone()
     }
-    pub fn build(&mut self) -> Result<UnicodeSegmentTokenizer, VTextError> {
+    pub fn build(&mut self) -> Result<UnicodeSegmentTokenizer, EstimatorErr> {
         Ok(UnicodeSegmentTokenizer {
             params: self.clone(),
         })
@@ -211,7 +211,7 @@ impl VTextTokenizerParams {
         self.lang = value.to_string();
         self.clone()
     }
-    pub fn build(&mut self) -> Result<VTextTokenizer, VTextError> {
+    pub fn build(&mut self) -> Result<VTextTokenizer, EstimatorErr> {
         let lang = match &self.lang[..] {
             "en" | "fr" => &self.lang[..],
             _ => {
@@ -372,7 +372,7 @@ impl CharacterTokenizerParams {
         self.window_size = value;
         self.clone()
     }
-    pub fn build(&mut self) -> Result<CharacterTokenizer, VTextError> {
+    pub fn build(&mut self) -> Result<CharacterTokenizer, EstimatorErr> {
         Ok(CharacterTokenizer {
             params: self.clone(),
         })

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -16,15 +16,11 @@ fn test_regexp_tokenizer() {
     assert_eq!(tokens, b);
 }
 
-
 #[test]
 fn test_regexp_tokenizer_error() {
-    let tokenizer = RegexpTokenizerParams::default()
-        .pattern("(")
-        .build();
+    let tokenizer = RegexpTokenizerParams::default().pattern("(").build();
 
     assert!(tokenizer.is_err());
-
 }
 
 #[test]

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -16,6 +16,17 @@ fn test_regexp_tokenizer() {
     assert_eq!(tokens, b);
 }
 
+
+#[test]
+fn test_regexp_tokenizer_error() {
+    let tokenizer = RegexpTokenizerParams::default()
+        .pattern("(")
+        .build();
+
+    assert!(tokenizer.is_err());
+
+}
+
 #[test]
 fn test_unicode_tokenizer() {
     let s = "The quick (\"brown\") fox can't jump 32.3 feet, right?";

--- a/src/tokenize_sentence/mod.rs
+++ b/src/tokenize_sentence/mod.rs
@@ -68,7 +68,7 @@ use dict_derive::{FromPyObject, IntoPyObject};
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::errors::VTextError;
+use crate::errors::EstimatorErr;
 use crate::tokenize::Tokenizer;
 
 use std::fmt;
@@ -95,7 +95,7 @@ pub struct UnicodeSentenceTokenizer {
 pub struct UnicodeSentenceTokenizerParams {}
 
 impl UnicodeSentenceTokenizerParams {
-    pub fn build(&mut self) -> Result<UnicodeSentenceTokenizer, VTextError> {
+    pub fn build(&mut self) -> Result<UnicodeSentenceTokenizer, EstimatorErr> {
         Ok(UnicodeSentenceTokenizer {
             params: self.clone(),
         })
@@ -150,7 +150,7 @@ impl PunctuationTokenizerParams {
         self.punctuation = punctuation.clone();
         self.clone()
     }
-    pub fn build(&mut self) -> Result<PunctuationTokenizer, VTextError> {
+    pub fn build(&mut self) -> Result<PunctuationTokenizer, EstimatorErr> {
         Ok(PunctuationTokenizer {
             params: self.clone(),
         })

--- a/src/vectorize/mod.rs
+++ b/src/vectorize/mod.rs
@@ -25,7 +25,7 @@ let X = vectorizer.fit_transform(&documents);
 // returns a sparse CSR matrix with document-terms counts
 */
 
-use crate::errors::VTextError;
+use crate::errors::EstimatorErr;
 use crate::math::CSRArray;
 use crate::tokenize::Tokenizer;
 
@@ -109,7 +109,7 @@ impl<T: Tokenizer + Clone> CountVectorizerParams<T> {
         self.n_jobs = value;
         self.clone()
     }
-    pub fn build(&mut self) -> Result<CountVectorizer<T>, VTextError> {
+    pub fn build(&mut self) -> Result<CountVectorizer<T>, EstimatorErr> {
         if self.n_jobs < 1 {
             panic!("n_jobs={} must be > 0", self.n_jobs);
         }
@@ -344,7 +344,7 @@ impl<T: Tokenizer + Clone> HashingVectorizerParams<T> {
         self.n_jobs = value;
         self.clone()
     }
-    pub fn build(&mut self) -> Result<HashingVectorizer<T>, VTextError> {
+    pub fn build(&mut self) -> Result<HashingVectorizer<T>, EstimatorErr> {
         if self.n_jobs < 1 {
             panic!("n_jobs={} must be > 0", self.n_jobs);
         }


### PR DESCRIPTION
Improves error handling by,
 - switching to [thiserror](https://github.com/dtolnay/thiserror) for deriving Error structs
 - rename `error::VTextError` to `error::EstimatorErr` with better enum variants
 - add explicit conversion to `pyo3::PyErr` with `impl From<EstimatorErr> for pyo3::PyErr`