### PR TITLE
Add StopWordFilter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ let tokens = tok.tokenize("Flights can't depart after 2:00 pm.");
 pub mod errors;
 mod math;
 pub mod metrics;
+pub mod token_processor;
 pub mod tokenize;
 pub mod tokenize_sentence;
-pub mod token_processor;
 pub mod vectorize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,4 +45,5 @@ mod math;
 pub mod metrics;
 pub mod tokenize;
 pub mod tokenize_sentence;
+pub mod token_processor;
 pub mod vectorize;

--- a/src/token_processor/mod.rs
+++ b/src/token_processor/mod.rs
@@ -1,0 +1,63 @@
+// Copyright 2019 vtext developers
+//
+// Licensed under the Apache License, Version 2.0,
+// <http://apache.org/licenses/LICENSE-2.0>. This file may not be copied,
+// modified, or distributed except according to those terms.
+
+/*!
+# Token processor modules
+
+This modules includes estimators that operate on tokens, for instance for stop words filtering,
+n-gram construction or stemming.
+*/
+
+use std::fmt;
+use std::collections::HashSet;
+use serde::{Deserialize, Serialize};
+use crate::errors::VTextError;
+
+pub trait TokenProcessor: fmt::Debug {
+    fn transform<'a>(&'a self, tokens: dyn Iterator<Item = &'a str>) -> Box<dyn Iterator<Item = &'a str> + 'a>;
+}
+
+/// Stop words filter
+///
+#[derive(Clone)]
+pub struct StopWordFilter {
+    pub params: StopWordFilterParams,
+}
+
+/// Builder for the stop words filter
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+pub struct StopWordFilterParams {
+    stop_words: HashSet<String>,
+}
+
+impl StopWordFilterParams {
+    pub fn stop_words(&mut self, value: Vec<&str>) -> StopWordFilterParams {
+        self.stop_words = value.iter().map(|el| el.to_string()).collect();
+        self.clone()
+    }
+    pub fn build(&mut self) -> Result<StopWordFilter, VTextError> {
+        Ok(StopWordFilter {
+            params: self.clone(),
+        })
+    }
+}
+
+impl Default for StopWordFilterParams {
+    /// Create a new instance
+    fn default() -> StopWordFilterParams {
+        StopWordFilterParams {
+            stop_words: vec!["and", "or", "this"].iter().map(|el| el.to_string()).collect()
+        }
+    }
+}
+
+impl Default for StopWordFilter {
+    /// Create a new instance
+    fn default() -> StopWordFilter {
+        StopWordFilterParams::default().build().unwrap()
+    }
+}

--- a/src/token_processor/mod.rs
+++ b/src/token_processor/mod.rs
@@ -11,18 +11,24 @@ This modules includes estimators that operate on tokens, for instance for stop w
 n-gram construction or stemming.
 */
 
-use std::fmt;
-use std::collections::HashSet;
-use serde::{Deserialize, Serialize};
 use crate::errors::VTextError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fmt;
+
+#[cfg(test)]
+mod tests;
 
 pub trait TokenProcessor: fmt::Debug {
-    fn transform<'a>(&'a self, tokens: dyn Iterator<Item = &'a str>) -> Box<dyn Iterator<Item = &'a str> + 'a>;
+    fn transform<'a>(
+        &'a self,
+        tokens: Box<dyn Iterator<Item = &'a str> + 'a>,
+    ) -> Box<dyn Iterator<Item = &'a str> + 'a>;
 }
 
 /// Stop words filter
 ///
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StopWordFilter {
     pub params: StopWordFilterParams,
 }
@@ -50,7 +56,10 @@ impl Default for StopWordFilterParams {
     /// Create a new instance
     fn default() -> StopWordFilterParams {
         StopWordFilterParams {
-            stop_words: vec!["and", "or", "this"].iter().map(|el| el.to_string()).collect()
+            stop_words: vec!["and", "or", "this"]
+                .iter()
+                .map(|el| el.to_string())
+                .collect(),
         }
     }
 }
@@ -60,4 +69,14 @@ impl Default for StopWordFilter {
     fn default() -> StopWordFilter {
         StopWordFilterParams::default().build().unwrap()
     }
+}
+
+impl TokenProcessor for StopWordFilter {
+    fn transform<'a>(
+        &'a self,
+        tokens: Box<dyn Iterator<Item = &'a str> + 'a>,
+    ) -> Box<dyn Iterator<Item = &'a str> + 'a>{
+        Box::new(tokens.filter(move |tok| !self.params.stop_words.contains(*tok)))
+    }
+
 }

--- a/src/token_processor/mod.rs
+++ b/src/token_processor/mod.rs
@@ -29,6 +29,8 @@ assert_eq!(tokens_out, vec!["is", "long", "sentence"]);
 
 use crate::errors::EstimatorErr;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "python")]
+use dict_derive::{FromPyObject, IntoPyObject};
 use std::collections::HashSet;
 use std::fmt;
 

--- a/src/token_processor/mod.rs
+++ b/src/token_processor/mod.rs
@@ -28,9 +28,9 @@ assert_eq!(tokens_out, vec!["is", "long", "sentence"]);
 */
 
 use crate::errors::EstimatorErr;
-use serde::{Deserialize, Serialize};
 #[cfg(feature = "python")]
 use dict_derive::{FromPyObject, IntoPyObject};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
 

--- a/src/token_processor/mod.rs
+++ b/src/token_processor/mod.rs
@@ -37,7 +37,8 @@ mod tests;
 
 pub trait TokenProcessor: fmt::Debug {
     fn transform<'a, T>(&'a self, tokens: T) -> Box<dyn Iterator<Item = &'a str> + 'a>
-    where T: Iterator<Item = &'a str> + 'a;
+    where
+        T: Iterator<Item = &'a str> + 'a;
 }
 
 /// Stop words filter
@@ -86,11 +87,9 @@ impl Default for StopWordFilter {
 }
 
 impl TokenProcessor for StopWordFilter {
-    fn transform<'a, T>(
-        &'a self,
-        tokens: T
-    ) -> Box<dyn Iterator<Item = &'a str> + 'a>
-    where T: Iterator<Item = &'a str> + 'a
+    fn transform<'a, T>(&'a self, tokens: T) -> Box<dyn Iterator<Item = &'a str> + 'a>
+    where
+        T: Iterator<Item = &'a str> + 'a,
     {
         Box::new(tokens.filter(move |tok| !self.params.stop_words.contains(*tok)))
     }

--- a/src/token_processor/tests.rs
+++ b/src/token_processor/tests.rs
@@ -1,0 +1,20 @@
+// Copyright 2019 vtext developers
+//
+// Licensed under the Apache License, Version 2.0,
+// <http://apache.org/licenses/LICENSE-2.0>. This file may not be copied,
+// modified, or distributed except according to those terms.
+use crate::token_processor::*;
+
+#[test]
+fn test_regexp_tokenizer() {
+    let stop_words = vec!["and", "or"];
+    let tokens = vec!["Today", "and", "tomorrow"];
+
+    let filter = StopWordFilterParams::default()
+        .stop_words(stop_words)
+        .build()
+        .unwrap();
+
+    let tokens_out: Vec<&str> = filter.transform(tokens.iter().cloned()).collect();
+    assert_eq!(tokens_out, vec!["Today", "tomorrow"]);
+}

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -47,9 +47,6 @@ let tokens: Vec<&str> = tokenizer.tokenize(s).collect();
 assert_eq!(tokens, &["The", "“", "brown", "”", "fox", "ca", "n't", "jump", "32.3", "feet", ",", "right", "?"]);
 
 */
-extern crate regex;
-extern crate unicode_segmentation;
-
 use crate::errors::EstimatorErr;
 #[cfg(feature = "python")]
 use dict_derive::{FromPyObject, IntoPyObject};


### PR DESCRIPTION
Add the `StopWordFilter` struct to filter stop words, as as example of a `TokenProcessor` trait implementation that takes in an iterator and returns an iterator of strings (following discussion in https://github.com/rth/vtext/issues/21)


### TODO
 - [ ] decide what should be the default stop word list: either take an english stop word list from somewhere (e.g. spacy), or ask users to explicitly provide one.