### PR TITLE
Treebank word tokenizer from NLTK

### DIFF
--- a/benchmarks/bench_tokenizers.py
+++ b/benchmarks/bench_tokenizers.py
@@ -23,6 +23,11 @@ try:
 except ImportError:
     blingfire = None
 
+try:
+    import nltk
+except ImportError:
+    nltk = None
+
 
 base_dir = Path(__file__).parent.parent.resolve()
 
@@ -70,6 +75,9 @@ if __name__ == "__main__":
 
     if blingfire is not None:
         db.append(("BlingFire en", lambda x: blingfire.text_to_words(x).split(" ")))
+
+    if nltk is not None:
+        db.append(('NLTK word_tokenize', nltk.tokenize.TreebankWordTokenizer().tokenize))
 
     for label, func in db:
         t0 = time()

--- a/benchmarks/bench_tokenizers.py
+++ b/benchmarks/bench_tokenizers.py
@@ -3,10 +3,13 @@ from glob import glob
 from pathlib import Path
 import re
 
-from vtext.tokenize import RegexpTokenizer
-from vtext.tokenize import UnicodeWordTokenizer
-from vtext.tokenize import VTextTokenizer
-from vtext.tokenize import CharacterTokenizer
+from vtext.tokenize import (
+    RegexpTokenizer,
+    UnicodeWordTokenizer,
+    VTextTokenizer,
+    CharacterTokenizer,
+    TreebankWordTokenizer
+)
 
 try:
     import sacremoses
@@ -64,6 +67,7 @@ if __name__ == "__main__":
         ),
         ("VTextTokenizer('en')", VTextTokenizer("en").tokenize),
         ("CharacterTokenizer(4)", CharacterTokenizer(4).tokenize),
+        ("TreebankWordTokenizer()", TreebankWordTokenizer().tokenize)
     ]
 
     if sacremoses is not None:
@@ -77,7 +81,7 @@ if __name__ == "__main__":
         db.append(("BlingFire en", lambda x: blingfire.text_to_words(x).split(" ")))
 
     if nltk is not None:
-        db.append(('NLTK word_tokenize', nltk.tokenize.TreebankWordTokenizer().tokenize))
+        db.append(('NLTK TreebankWordTokenizer', nltk.tokenize.TreebankWordTokenizer().tokenize))
 
     for label, func in db:
         t0 = time()

--- a/benchmarks/bench_tokenizers.py
+++ b/benchmarks/bench_tokenizers.py
@@ -8,7 +8,7 @@ from vtext.tokenize import (
     UnicodeWordTokenizer,
     VTextTokenizer,
     CharacterTokenizer,
-    TreebankWordTokenizer
+    NTLKWordTokenizer
 )
 
 try:
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         ),
         ("VTextTokenizer('en')", VTextTokenizer("en").tokenize),
         ("CharacterTokenizer(4)", CharacterTokenizer(4).tokenize),
-        ("TreebankWordTokenizer()", TreebankWordTokenizer().tokenize)
+        ("NTLKWordTokenizer()", NTLKWordTokenizer().tokenize)
     ]
 
     if sacremoses is not None:
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         db.append(("BlingFire en", lambda x: blingfire.text_to_words(x).split(" ")))
 
     if nltk is not None:
-        db.append(('NLTK TreebankWordTokenizer', nltk.tokenize.TreebankWordTokenizer().tokenize))
+        db.append(('NLTK NLTKWordTokenizer', nltk.tokenize.NLTKWordTokenizer().tokenize))
 
     for label, func in db:
         t0 = time()

--- a/evaluation/eval_tokenization.py
+++ b/evaluation/eval_tokenization.py
@@ -7,7 +7,7 @@ import conllu
 import pandas as pd
 import numpy as np
 
-from vtext.tokenize import UnicodeWordTokenizer, VTextTokenizer
+from vtext.tokenize import UnicodeWordTokenizer, VTextTokenizer, NTLKWordTokenizer
 
 try:
     import sacremoses
@@ -73,6 +73,7 @@ tok_db = [
         lambda lang: UnicodeWordTokenizer(word_bounds=True).tokenize,
     ),
     ("vtext", lambda lang: VTextTokenizer(lang).tokenize),
+    ("NTLKWordTokenizer", lambda lang: NTLKWordTokenizer().tokenize)
 ]
 
 if sacremoses is not None:
@@ -125,4 +126,7 @@ out = (
     .score.unstack(-1)
     .round(3)
 )
+
+pd.set_option('display.width', 120)
+pd.set_option('display.max_columns', 500)
 print(out)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -182,6 +182,7 @@ fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenize::RegexpTokenizer>()?;
     m.add_class::<tokenize::VTextTokenizer>()?;
     m.add_class::<tokenize::CharacterTokenizer>()?;
+    m.add_class::<tokenize::TreebankWordTokenizer>()?;
     m.add_class::<stem::SnowballStemmer>()?;
     m.add_wrapped(wrap_pyfunction!(dice_similarity))?;
     m.add_wrapped(wrap_pyfunction!(jaro_similarity))?;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -182,7 +182,7 @@ fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenize::RegexpTokenizer>()?;
     m.add_class::<tokenize::VTextTokenizer>()?;
     m.add_class::<tokenize::CharacterTokenizer>()?;
-    m.add_class::<tokenize::TreebankWordTokenizer>()?;
+    m.add_class::<tokenize::NTLKWordTokenizer>()?;
     m.add_class::<stem::SnowballStemmer>()?;
     m.add_wrapped(wrap_pyfunction!(dice_similarity))?;
     m.add_wrapped(wrap_pyfunction!(jaro_similarity))?;

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -305,3 +305,63 @@ impl CharacterTokenizer {
         Ok(())
     }
 }
+
+
+/// __init__(self, pattern=r'\\b\\w\\w+\\b')
+///
+/// Tokenize a 
+#[pyclass(extends=BaseTokenizer, module="vtext.tokenize")]
+pub struct TreebankWordTokenizer {
+    inner: vtext::tokenize::TreebankWordTokenizer,
+}
+
+#[pymethods]
+impl TreebankWordTokenizer {
+    #[new]
+    fn new() -> PyResult<(Self, BaseTokenizer)> {
+        let inner = vtext::tokenize::TreebankWordTokenizer::default();
+
+        Ok((TreebankWordTokenizer { inner }, BaseTokenizer::new()))
+    }
+
+    /// tokenize(self, x)
+    ///
+    /// Tokenize a string
+    ///
+    /// Parameters
+    /// ----------
+    /// x : bool
+    ///    the string to tokenize
+    ///
+    /// Returns
+    /// -------
+    /// tokens : List[str]
+    ///    computed tokens
+    fn tokenize<'py>(&self, py: Python<'py>, x: &str) -> PyResult<&'py PyList> {
+        let res: Vec<String> = self.inner.tokenize(x);
+        let list = PyList::new(py, res);
+        Ok(list)
+    }
+
+    /// get_params(self, x)
+    ///
+    /// Get parameters for this estimator.
+    ///
+    /// Returns
+    /// -------
+    /// params : mapping of string to any
+    ///          Parameter names mapped to their values.
+    fn get_params(&self) -> PyResult<TreebankWordTokenizerParams> {
+        Ok(self.inner.params.clone())
+    }
+
+    pub fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+        serialize_params(&self.inner.params, py)
+    }
+
+    pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+        let mut params: TreebankWordTokenizerParams = deserialize_params(py, state)?;
+        self.inner = params.build()?;
+        Ok(())
+    }
+}

--- a/python/src/tokenize.rs
+++ b/python/src/tokenize.rs
@@ -311,17 +311,17 @@ impl CharacterTokenizer {
 ///
 /// Tokenize a 
 #[pyclass(extends=BaseTokenizer, module="vtext.tokenize")]
-pub struct TreebankWordTokenizer {
-    inner: vtext::tokenize::TreebankWordTokenizer,
+pub struct NTLKWordTokenizer {
+    inner: vtext::tokenize::NTLKWordTokenizer,
 }
 
 #[pymethods]
-impl TreebankWordTokenizer {
+impl NTLKWordTokenizer {
     #[new]
     fn new() -> PyResult<(Self, BaseTokenizer)> {
-        let inner = vtext::tokenize::TreebankWordTokenizer::default();
+        let inner = vtext::tokenize::NTLKWordTokenizer::default();
 
-        Ok((TreebankWordTokenizer { inner }, BaseTokenizer::new()))
+        Ok((NTLKWordTokenizer { inner }, BaseTokenizer::new()))
     }
 
     /// tokenize(self, x)
@@ -351,7 +351,7 @@ impl TreebankWordTokenizer {
     /// -------
     /// params : mapping of string to any
     ///          Parameter names mapped to their values.
-    fn get_params(&self) -> PyResult<TreebankWordTokenizerParams> {
+    fn get_params(&self) -> PyResult<NTLKWordTokenizerParams> {
         Ok(self.inner.params.clone())
     }
 
@@ -360,7 +360,7 @@ impl TreebankWordTokenizer {
     }
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
-        let mut params: TreebankWordTokenizerParams = deserialize_params(py, state)?;
+        let mut params: NTLKWordTokenizerParams = deserialize_params(py, state)?;
         self.inner = params.build()?;
         Ok(())
     }

--- a/python/vtext/tests/test_common.py
+++ b/python/vtext/tests/test_common.py
@@ -11,6 +11,7 @@ from vtext.tokenize import (
     RegexpTokenizer,
     UnicodeWordTokenizer,
     VTextTokenizer,
+    TreebankWordTokenizer,
 )
 from vtext.tokenize_sentence import UnicodeSentenceTokenizer, PunctuationTokenizer
 from vtext.stem import SnowballStemmer
@@ -21,6 +22,7 @@ TOKENIZERS = [
     RegexpTokenizer,
     UnicodeWordTokenizer,
     VTextTokenizer,
+    TreebankWordTokenizer,
 ]
 
 SENTENCE_TOKENIZERS = [UnicodeSentenceTokenizer, PunctuationTokenizer]

--- a/python/vtext/tokenize.py
+++ b/python/vtext/tokenize.py
@@ -10,7 +10,7 @@ from ._lib import (
     RegexpTokenizer,
     VTextTokenizer,
     CharacterTokenizer,
-    TreebankWordTokenizer,
+    NTLKWordTokenizer,
 )
 
 
@@ -20,5 +20,5 @@ __all__ = [
     "RegexpTokenizer",
     "VTextTokenizer",
     "CharacterTokenizer",
-    "TreebankWordTokenizer",
+    "NTLKWordTokenizer",
 ]

--- a/python/vtext/tokenize.py
+++ b/python/vtext/tokenize.py
@@ -4,11 +4,14 @@
 # <http://apache.org/licenses/LICENSE-2.0>. This file may not be copied,
 # modified, or distributed except according to those terms.
 
-from ._lib import BaseTokenizer
-from ._lib import UnicodeWordTokenizer
-from ._lib import RegexpTokenizer
-from ._lib import VTextTokenizer
-from ._lib import CharacterTokenizer
+from ._lib import (
+    BaseTokenizer,
+    UnicodeWordTokenizer,
+    RegexpTokenizer,
+    VTextTokenizer,
+    CharacterTokenizer,
+    TreebankWordTokenizer,
+)
 
 
 __all__ = [
@@ -17,4 +20,5 @@ __all__ = [
     "RegexpTokenizer",
     "VTextTokenizer",
     "CharacterTokenizer",
+    "TreebankWordTokenizer",
 ]

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -411,13 +411,11 @@ impl Tokenizer for CharacterTokenizer {
 /// Regular expression tokenizer
 ///
 #[derive(Clone)]
-pub struct TreebankWordTokenizer {
-    pub params: TreebankWordTokenizerParams,
+pub struct NTLKWordTokenizer {
+    pub params: NTLKWordTokenizerParams,
     stage1_regex: Vec<(Regex, String)>,
     stage2_regex: Vec<(Regex, String)>,
 }
-
-
 
 macro_rules! regexReplacementVec {
     ($( ($pattern:expr, $value:expr) ),*) => {{
@@ -427,15 +425,13 @@ macro_rules! regexReplacementVec {
     }}
 }
 
-
-impl TreebankWordTokenizer {
-    pub fn new() -> TreebankWordTokenizer {
+impl NTLKWordTokenizer {
+    pub fn new() -> NTLKWordTokenizer {
         let stage1_regex = regexReplacementVec![
             // starting quotes
             ("^\"", "``"),
             ("(``)", " $1 "),
-            // ("([ \\(\\[{<])(\"|\'{2})"
-
+            ("([ \\(\\[{<])(\"|\'{2})", r"$1 `` "),
             // Punctuation
             (r"([:,])([^\d])", " $1 $2"),
             (r"([:,])$", " $1"),
@@ -446,10 +442,8 @@ impl TreebankWordTokenizer {
             (r"([^'])' ", "$1 ' "),
             // Pad parentheses
             (r"([\]\[\(\)\{\}<>])", r" $1 "),
-
             // Double dashed
             ("--", " -- ")
-
         ];
 
         let stage2_regex = regexReplacementVec![
@@ -458,10 +452,9 @@ impl TreebankWordTokenizer {
             (r"(\S)('')", "$1 $2 "),
             (r"([^' ])('[sS]|'[mM]|'[dD]|') ", "$1 $2 "),
             (r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T)", "$1 $2 "),
-
             // List of contractions adapted from Robert MacIntyre's tokenizer.
             // CONTRACTIONS2
-            (r"(?i)\b(can)(not)\b", " $1 $2 "), 
+            (r"(?i)\b(can)(not)\b", " $1 $2 "),
             (r"(?i)\b(d)('ye)\b", " $1 $2 "),
             (r"(?i)\b(gim)(me)\b", " $1 $2 "),
             (r"(?i)\b(gon)(na)\b", " $1 $2 "),
@@ -473,10 +466,10 @@ impl TreebankWordTokenizer {
             (r"(?i) ('t)(is)\b", " $1 $2 "),
             (r"(?i) ('t)(was)\b", " $1 $2 ")
         ];
-        TreebankWordTokenizer {
-            params: TreebankWordTokenizerParams::default(),
+        NTLKWordTokenizer {
+            params: NTLKWordTokenizerParams::default(),
             stage1_regex,
-            stage2_regex
+            stage2_regex,
         }
     }
     pub fn tokenize<'a>(&'a self, text: &'a str) -> Vec<String> {
@@ -487,7 +480,7 @@ impl TreebankWordTokenizer {
         out = format!(" {} ", out);
 
         // add extra space to make things easier
-        for (regexp_obj, subst) in self.stage1_regex.iter() {
+        for (regexp_obj, subst) in self.stage2_regex.iter() {
             out = regexp_obj.replace_all(&out, subst.as_str()).to_string();
         }
         let x = out.split_whitespace().map(|el| el.to_string()).to_owned();
@@ -499,30 +492,30 @@ impl TreebankWordTokenizer {
 /// Builder for the regexp tokenizer
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
-pub struct TreebankWordTokenizerParams {}
+pub struct NTLKWordTokenizerParams {}
 
-impl TreebankWordTokenizerParams {
-    pub fn build(&mut self) -> Result<TreebankWordTokenizer, EstimatorErr> {
-        Ok(TreebankWordTokenizer::new())
+impl NTLKWordTokenizerParams {
+    pub fn build(&mut self) -> Result<NTLKWordTokenizer, EstimatorErr> {
+        Ok(NTLKWordTokenizer::new())
     }
 }
 
-impl Default for TreebankWordTokenizerParams {
+impl Default for NTLKWordTokenizerParams {
     /// Create a new instance
-    fn default() -> TreebankWordTokenizerParams {
-        TreebankWordTokenizerParams {}
+    fn default() -> NTLKWordTokenizerParams {
+        NTLKWordTokenizerParams {}
     }
 }
 
-impl Default for TreebankWordTokenizer {
+impl Default for NTLKWordTokenizer {
     /// Create a new instance
-    fn default() -> TreebankWordTokenizer {
-        TreebankWordTokenizerParams::default().build().unwrap()
+    fn default() -> NTLKWordTokenizer {
+        NTLKWordTokenizerParams::default().build().unwrap()
     }
 }
 
-impl fmt::Debug for TreebankWordTokenizer {
+impl fmt::Debug for NTLKWordTokenizer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TreebankWordTokenizer {{ }}")
+        write!(f, "NTLKWordTokenizer {{ }}")
     }
 }

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -435,7 +435,7 @@ impl NTLKWordTokenizer {
             ("([ \\(\\[{<])(\"|\'{2})", r"$1 `` "),
             // Can't do negative lookahead with regex crate
             // (r"(?i)(')(?!re|ve|ll|m|t|s|d)(\w)\b", r"$1 $2"),
-            
+
             // Punctuation
             ("([^\\.])(\\.)([\\]\\)}>\"'»”’ \" r\"]*)\\s*$", "$1 $2 $3"),
             (r"([:,])([^\d])", " $1 $2"),
@@ -445,7 +445,7 @@ impl NTLKWordTokenizer {
             ("([^\\.])(\\.)([\\]\\)}>\"\']*)\\s*$", "$1 $2 $3"),
             (r"([?!])", " $1 "),
             (r"([^'])' ", "$1 ' "),
-            (r"[*]", " $1 "), 
+            (r"[*]", " $1 "),
             // Pad parentheses
             (r"([\]\[\(\)\{\}<>])", r" $1 "),
             // Double dashed

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -429,17 +429,23 @@ impl NTLKWordTokenizer {
     pub fn new() -> NTLKWordTokenizer {
         let stage1_regex = regexReplacementVec![
             // starting quotes
+            ("([«“‘„]|[`]+)", " $1 "),
             ("^\"", "``"),
             ("(``)", " $1 "),
             ("([ \\(\\[{<])(\"|\'{2})", r"$1 `` "),
+            // Can't do negative lookahead with regex crate
+            // (r"(?i)(')(?!re|ve|ll|m|t|s|d)(\w)\b", r"$1 $2"),
+            
             // Punctuation
+            ("([^\\.])(\\.)([\\]\\)}>\"'»”’ \" r\"]*)\\s*$", "$1 $2 $3"),
             (r"([:,])([^\d])", " $1 $2"),
             (r"([:,])$", " $1"),
-            (r"\.\.\.", " ... "),
+            (r"\.{2,}", " $1 "),
             (r"([;@#$%&])", " $1 "),
             ("([^\\.])(\\.)([\\]\\)}>\"\']*)\\s*$", "$1 $2 $3"),
             (r"([?!])", " $1 "),
             (r"([^'])' ", "$1 ' "),
+            (r"[*]", " $1 "), 
             // Pad parentheses
             (r"([\]\[\(\)\{\}<>])", r" $1 "),
             // Double dashed
@@ -448,6 +454,7 @@ impl NTLKWordTokenizer {
 
         let stage2_regex = regexReplacementVec![
             // ending quotes
+            ("([»”’])", " $1 "),
             ("\"", " '' "),
             (r"(\S)('')", "$1 $2 "),
             (r"([^' ])('[sS]|'[mM]|'[dD]|') ", "$1 $2 "),

--- a/src/tokenize/mod.rs
+++ b/src/tokenize/mod.rs
@@ -479,13 +479,11 @@ impl TreebankWordTokenizer {
             stage2_regex
         }
     }
-    fn tokenize<'a>(&'a self, text: &'a str) -> Vec<String> {
+    pub fn tokenize<'a>(&'a self, text: &'a str) -> Vec<String> {
         let mut out = text.to_string();
         for (regexp_obj, subst) in self.stage1_regex.iter() {
             out = regexp_obj.replace_all(&out, subst.as_str()).to_string();
         }
-        println!("{}", out);
-
         out = format!(" {} ", out);
 
         // add extra space to make things easier

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -226,43 +226,65 @@ fn test_treebank_word_tokenizer() {
     let s = "The company spent 40.75% of its income last year.";
     let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
-     "The", "company", "spent", "40.75", "%", "of", "its", "income", "last", "year", "."
+        "The", "company", "spent", "40.75", "%", "of", "its", "income", "last", "year", ".",
     ];
     assert_eq!(tokens, b);
 
     let s = "He arrived at 3:00 pm.";
     let tokens = tokenizer.tokenize(s);
-    let b: &[_] = &[
-         "He", "arrived", "at", "3:00", "pm", "."
-    ];
+    let b: &[_] = &["He", "arrived", "at", "3:00", "pm", "."];
     assert_eq!(tokens, b);
 
     let s = "I bought these items: books, pencils, and pens.";
     let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
-         "I", "bought", "these", "items", ":", "books", ",", "pencils", ",", "and", "pens", "."
+        "I", "bought", "these", "items", ":", "books", ",", "pencils", ",", "and", "pens", ".",
     ];
     assert_eq!(tokens, b);
 
     let s = "Though there were 150, 100 of them were old.";
     let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
-        "Though", "there", "were", "150", ",", "100", "of", "them", "were", "old", "."
+        "Though", "there", "were", "150", ",", "100", "of", "them", "were", "old", ".",
     ];
     assert_eq!(tokens, b);
 
     let s = "There were 300,000, but that wasn't enough.";
     let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
-         "There", "were", "300,000", ",", "but", "that", "was", "n't", "enough", "."
+        "There", "were", "300,000", ",", "but", "that", "was", "n't", "enough", ".",
     ];
     assert_eq!(tokens, b);
 
     // Handling of unicode
     let s = "«Now that I can do.»";
     let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &["«", "Now", "that", "I", "can", "do", ".", "»"];
+    assert_eq!(tokens, b);
+
+    let s = "The unicode 201C and 201D \u{201c}LEFT(RIGHT) DOUBLE QUOTATION MARK\u{201d} is also OPEN_PUNCT and CLOSE_PUNCT.";
+    let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
-         "«", "Now", "that", "I", "can", "do", ".", "»"
+        "The",
+        "unicode",
+        "201C",
+        "and",
+        "201D",
+        "\u{201c}",
+        "LEFT",
+        "(",
+        "RIGHT",
+        ")",
+        "DOUBLE",
+        "QUOTATION",
+        "MARK",
+        "\u{201d}",
+        "is",
+        "also",
+        "OPEN_PUNCT",
+        "and",
+        "CLOSE_PUNCT",
+        ".",
     ];
     assert_eq!(tokens, b);
 }

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -131,3 +131,17 @@ fn test_tokenizer_defaults() {
     let tokenizer = UnicodeWordTokenizer::default();
     assert_eq!(tokenizer.params.word_bounds, true);
 }
+
+
+#[test]
+fn test_treebank_word_tokenizer() {
+    let s = "The,quick (\"brown\") fox can't jump 32.3 feet, right?";
+
+    let tokenizer = TreebankWordTokenizer::default();
+
+    let tokens: Vec<String> = tokenizer.tokenize(s).collect();
+    let b: &[_] = &[
+        "The", "quick", "brown", "fox", "can't", "jump", "32.3", "feet", "right",
+    ];
+    assert_eq!(tokens, b);
+}

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -264,6 +264,5 @@ fn test_treebank_word_tokenizer() {
     let b: &[_] = &[
          "«", "Now", "that", "I", "can", "do", ".", "»"
     ];
-    // TODO
-    // assert_eq!(tokens, b);
+    assert_eq!(tokens, b);
 }

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -134,13 +134,136 @@ fn test_tokenizer_defaults() {
 
 #[test]
 fn test_treebank_word_tokenizer() {
-    let s = "The,quick (\"brown\") fox can't jump 32.3 feet, right?";
+    let tokenizer = NTLKWordTokenizer::default();
 
-    let tokenizer = TreebankWordTokenizer::default();
-
+    // test cases from NLTK
+    // https://github.com/nltk/nltk/blob/develop/nltk/test/tokenize.doctest
+    let s = "On a $50,000 mortgage of 30 years at 8 percent, the monthly payment would be $366.88.";
     let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
-        "The", "quick", "brown", "fox", "can't", "jump", "32.3", "feet", "right",
+        "On", "a", "$", "50,000", "mortgage", "of", "30", "years", "at", "8", "percent", ",",
+        "the", "monthly", "payment", "would", "be", "$", "366.88", ".",
     ];
     assert_eq!(tokens, b);
+
+    let s = "\"We beat some pretty good teams to get here,\" Slocum said.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+        "``", "We", "beat", "some", "pretty", "good", "teams", "to", "get", "here", ",", "''",
+        "Slocum", "said", ".",
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "Well, we couldn't have this predictable, cliche-ridden, \"Touched by an Angel\" (a show creator John Masius worked on) wanna-be if she didn't.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+        "Well",
+        ",",
+        "we",
+        "could",
+        "n\"t",
+        "have",
+        "this",
+        "predictable",
+        ",",
+        "cliche-ridden",
+        ",",
+        "``",
+        "Touched",
+        "by",
+        "an",
+        "Angel",
+        "\"\"",
+        "(",
+        "a",
+        "show",
+        "creator",
+        "John",
+        "Masius",
+        "worked",
+        "on",
+        ")",
+        "wanna-be",
+        "if",
+        "she",
+        "did",
+        "n\"t",
+        ".",
+    ];
+    // TODO
+    // assert_eq!(tokens, b);
+
+    let s = "I cannot cannot work under these conditions!";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+        "I",
+        "can",
+        "not",
+        "can",
+        "not",
+        "work",
+        "under",
+        "these",
+        "conditions",
+        "!",
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "The company spent $30,000,000 last year.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+        "The",
+        "company",
+        "spent",
+        "$",
+        "30,000,000",
+        "last",
+        "year",
+        ".",
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "The company spent 40.75% of its income last year.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+     "The", "company", "spent", "40.75", "%", "of", "its", "income", "last", "year", "."
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "He arrived at 3:00 pm.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+         "He", "arrived", "at", "3:00", "pm", "."
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "I bought these items: books, pencils, and pens.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+         "I", "bought", "these", "items", ":", "books", ",", "pencils", ",", "and", "pens", "."
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "Though there were 150, 100 of them were old.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+        "Though", "there", "were", "150", ",", "100", "of", "them", "were", "old", "."
+    ];
+    assert_eq!(tokens, b);
+
+    let s = "There were 300,000, but that wasn't enough.";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+         "There", "were", "300,000", ",", "but", "that", "was", "n't", "enough", "."
+    ];
+    assert_eq!(tokens, b);
+
+    // Handling of unicode
+    let s = "«Now that I can do.»";
+    let tokens = tokenizer.tokenize(s);
+    let b: &[_] = &[
+         "«", "Now", "that", "I", "can", "do", ".", "»"
+    ];
+    // TODO
+    // assert_eq!(tokens, b);
 }

--- a/src/tokenize/tests.rs
+++ b/src/tokenize/tests.rs
@@ -132,14 +132,13 @@ fn test_tokenizer_defaults() {
     assert_eq!(tokenizer.params.word_bounds, true);
 }
 
-
 #[test]
 fn test_treebank_word_tokenizer() {
     let s = "The,quick (\"brown\") fox can't jump 32.3 feet, right?";
 
     let tokenizer = TreebankWordTokenizer::default();
 
-    let tokens: Vec<String> = tokenizer.tokenize(s).collect();
+    let tokens = tokenizer.tokenize(s);
     let b: &[_] = &[
         "The", "quick", "brown", "fox", "can't", "jump", "32.3", "feet", "right",
     ];


### PR DESCRIPTION
This adds a `NTLKWordTokenizer` which implements the default tokenizer from NLTK. The test suite from NLTK passes, however we are not handling [one edge case](https://github.com/rth/vtext/compare/TreebankWordTokenizer?expand=1#diff-73e49652121ea983d5a2f4be959e0802R437) due to the lack of the  lookahead functionality in regex. I don't think it's worth adding another library as a dependency to address that, and marking it as a known limitation could be a workaround for now. That regexp is an enhancement proposed by NLTK on top of the classical Penn Treebank word tokenizer. 

Currently this returns `Vec<String>` and I have struggled with making it return an iterator due to lifetime issues so far.

It's around 3x faster than the NLTK version in Python. It is very English specific and should probably not be used in other languages. 

TODO:
 - [ ] improve documentation